### PR TITLE
Fix stale workflow quoting

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: “Mark Stale Issues and PRs”
+name: "Mark Stale Issues and PRs"
 
 on:
   schedule:


### PR DESCRIPTION
## Summary
- use ASCII quotes in `.github/workflows/stale.yml`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef7ba6e4c83319e9af8a4770256dd