### PR TITLE
Fix tokenization loop and add regression test

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ export function tokenize(code, { verbose = false } = {}) {
   const stream = new CharStream(code);
   const lexer = new LexerEngine(stream);
   const tokens = [];
-  while (!stream.eof()) {
+  while (true) {
     const tok = lexer.nextToken();
+    if (tok === null) break;
     tokens.push(tok);
     if (verbose) console.log(tok);
   }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -3,3 +3,9 @@ test("integration: var declaration", () => {
   const toks = tokenize("let x = 5;");
   expect(toks.map(t => t.type)).toEqual(["KEYWORD","IDENTIFIER","OPERATOR","NUMBER","PUNCTUATION"]);
 });
+
+test("integration: trailing whitespace does not produce null token", () => {
+  const toks = tokenize("let x = 5;   ");
+  expect(toks).not.toContain(null);
+  expect(toks.map(t => t.type)).toEqual(["KEYWORD","IDENTIFIER","OPERATOR","NUMBER","PUNCTUATION"]);
+});


### PR DESCRIPTION
## Summary
- stop lexing when `nextToken()` returns `null`
- ensure no `null` tokens for trailing whitespace
- test that tokenizing `'let x = 5;   '` omits `null`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0559e11c8331a61c6fa5a4448600