### PR TITLE
Implement template string reader

### DIFF
--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -1,6 +1,74 @@
 /**
- * TODO(codex): Read TEMPLATE_STRING tokens with embedded expressions.
+ * Reads ECMAScript template strings, including `${}` interpolations.
+ * Returns a `TEMPLATE_STRING` token containing the raw text of the template.
  */
 export function TemplateStringReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '`') return null;
+
+  let value = '';
+
+  // consume opening backtick
+  value += stream.current();
+  stream.advance();
+
+  while (!stream.eof()) {
+    let ch = stream.current();
+
+    // handle escapes inside the template
+    if (ch === '\\') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+      if (ch !== null) {
+        value += ch;
+        stream.advance();
+      }
+      continue;
+    }
+
+    // closing backtick -> end of template literal
+    if (ch === '`') {
+      value += ch;
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('TEMPLATE_STRING', value, startPos, endPos);
+    }
+
+    // start of interpolation
+    if (ch === '$' && stream.peek() === '{') {
+      value += ch;
+      stream.advance();
+      value += stream.current(); // '{'
+      stream.advance();
+
+      let braceCount = 1;
+      while (!stream.eof() && braceCount > 0) {
+        ch = stream.current();
+        if (ch === '\\') {
+          value += ch;
+          stream.advance();
+          if (!stream.eof()) {
+            value += stream.current();
+            stream.advance();
+          }
+          continue;
+        }
+        if (ch === '{') braceCount++;
+        if (ch === '}') braceCount--;
+        value += ch;
+        stream.advance();
+        if (braceCount === 0) break;
+      }
+      continue;
+    }
+
+    // regular character within template
+    value += ch;
+    stream.advance();
+  }
+
+  // reached EOF without closing backtick - still return token
+  const endPos = stream.getPosition();
+  return factory('TEMPLATE_STRING', value, startPos, endPos);
 }

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -1,8 +1,17 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { TemplateStringReader } from "../../src/lexer/TemplateStringReader.js";
 
-test("TemplateStringReader placeholder", () => {
-  const stream = new CharStream("`template ${expr}`");
-  const token = TemplateStringReader(stream, () => {});
-  expect(token).toBeNull();
+test("TemplateStringReader reads template with interpolation", () => {
+  const src = "`template ${expr}`";
+  const stream = new CharStream(src);
+  const token = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("TEMPLATE_STRING");
+  expect(token.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});
+
+test("TemplateStringReader returns null for non-backtick start", () => {
+  const stream = new CharStream("'not template'");
+  expect(TemplateStringReader(stream, () => {})).toBeNull();
 });


### PR DESCRIPTION
## Summary
- support template strings in `TemplateStringReader`
- test template string tokenization

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f058365b4833193d0ce1e8cdc287a