### PR TITLE
Implement context-aware RegexOrDivideReader

### DIFF
--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -1,6 +1,90 @@
-/**
- * TODO(codex): Read regex literals vs DIVIDE operator.
- */
+// §4.5 RegexOrDivideReader
+// This reader is context aware. Based on surrounding characters it decides
+// whether the current `/` begins a regular expression literal or represents
+// the divide operator. It is intentionally heuristic and lightweight.
 export function RegexOrDivideReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '/') return null;
+
+  // Look at the previous non-whitespace character to guess context.
+  let i = stream.index - 1;
+  let prev = null;
+  while (i >= 0) {
+    const ch = stream.input[i];
+    if (/\s/.test(ch)) {
+      i--;
+      continue;
+    }
+    prev = ch;
+    break;
+  }
+
+  // Characters that commonly precede a regex literal. If none is found we
+  // assume divide operator.
+  const regexStarters = new Set([
+    '(', '{', '[', '=', ':', ',', ';', '!', '?', '+', '-', '*', '%', '&', '|',
+    '^', '~', '<', '>'
+  ]);
+  const treatAsRegex = prev === null || regexStarters.has(prev);
+
+  if (!treatAsRegex) {
+    // Divide or "/=" operator
+    stream.advance();
+    if (stream.current() === '=') {
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('OPERATOR', '/=', startPos, endPos);
+    }
+    const endPos = stream.getPosition();
+    return factory('OPERATOR', '/', startPos, endPos);
+  }
+
+  // Parse a regular expression literal of form /pattern/flags
+  stream.advance(); // consume opening '/'
+  let body = '';
+  let ch = stream.current();
+  let escaped = false;
+  while (ch !== null) {
+    if (!escaped && ch === '/') {
+      break;
+    }
+    if (!escaped && ch === '\\') {
+      escaped = true;
+      body += ch;
+      stream.advance();
+      ch = stream.current();
+      if (ch === null) break;
+      body += ch;
+      stream.advance();
+      escaped = false;
+      ch = stream.current();
+      continue;
+    }
+    body += ch;
+    escaped = false;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  if (ch !== '/') {
+    // Unterminated regex literal -> treat as divide fallback.
+    // Reset position and return null so other readers may handle.
+    stream.index = startPos.index;
+    stream.line = startPos.line;
+    stream.column = startPos.column;
+    return null;
+  }
+
+  stream.advance(); // consume closing '/'
+  let flags = '';
+  ch = stream.current();
+  while (ch !== null && /[a-z]/i.test(ch)) {
+    flags += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  const endPos = stream.getPosition();
+  const value = `/${body}/${flags}`;
+  return factory('REGEX', value, startPos, endPos);
 }

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -1,8 +1,31 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { RegexOrDivideReader } from "../../src/lexer/RegexOrDivideReader.js";
 
-test("RegexOrDivideReader placeholder", () => {
-  const stream = new CharStream("/abc/");
-  const token = RegexOrDivideReader(stream, () => {});
-  expect(token).toBeNull();
+// Regex literal at beginning of input
+test("RegexOrDivideReader reads regex literal", () => {
+  const stream = new CharStream("/abc/g");
+  const token = RegexOrDivideReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/abc/g");
+  expect(stream.getPosition().index).toBe(6);
+});
+
+// Divide operator when preceded by identifier
+test("RegexOrDivideReader reads divide operator", () => {
+  const stream = new CharStream("a/b");
+  stream.advance(); // move to '/'
+  const token = RegexOrDivideReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("OPERATOR");
+  expect(token.value).toBe("/");
+  expect(stream.getPosition().index).toBe(2);
+});
+
+// '/=' operator
+test("RegexOrDivideReader reads /= operator", () => {
+  const stream = new CharStream("/=b");
+  const token = RegexOrDivideReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("OPERATOR");
+  expect(token.value).toBe("/=");
+  expect(stream.getPosition().index).toBe(2);
 });


### PR DESCRIPTION
## Summary
- implement RegexOrDivideReader to distinguish regex literals from divide operators
- add tests for regex literal, divide operator, and `/=` operator

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0583f514833196cd2283da342688