### PR TITLE
Fix IdentifierReader import

### DIFF
--- a/src/lexer/IdentifierReader.js
+++ b/src/lexer/IdentifierReader.js
@@ -1,6 +1,4 @@
 // §4.1 IdentifierReader
-import { patterns } from '../grammar/JavaScriptGrammar.js';
-
 export function IdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();


### PR DESCRIPTION
## Summary
- remove invalid patterns import so IdentifierReader doesn't throw

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f05859f948331974e9dfd57d31659