### PR TITLE
Implement template string reader

### DIFF
--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -1,6 +1,73 @@
-/**
- * TODO(codex): Read TEMPLATE_STRING tokens with embedded expressions.
- */
+// §4.6 TemplateStringReader
+// Very small implementation that reads JavaScript template strings. It does not
+// attempt to fully parse the expressions inside `${}` – it simply scans forward
+// until matching braces and the closing backtick are found.
 export function TemplateStringReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '`') return null;
+
+  let value = '';
+  // consume starting backtick
+  value += stream.current();
+  stream.advance();
+
+  while (!stream.eof()) {
+    let ch = stream.current();
+
+    // handle escape sequences
+    if (ch === '\\') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+      if (ch !== null) {
+        value += ch;
+        stream.advance();
+      }
+      continue;
+    }
+
+    // closing backtick ends the template string
+    if (ch === '`') {
+      value += ch;
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('TEMPLATE_STRING', value, startPos, endPos);
+    }
+
+    // embedded expression
+    if (ch === '$' && stream.peek() === '{') {
+      value += ch;
+      stream.advance();
+      ch = stream.current(); // '{'
+      value += ch;
+      stream.advance();
+
+      let depth = 1;
+      while (!stream.eof() && depth > 0) {
+        ch = stream.current();
+        if (ch === '\\') {
+          value += ch;
+          stream.advance();
+          if (!stream.eof()) {
+            value += stream.current();
+            stream.advance();
+          }
+          continue;
+        }
+        if (ch === '{') depth++;
+        if (ch === '}') depth--;
+        value += ch;
+        stream.advance();
+      }
+      continue;
+    }
+
+    // regular character inside template
+    value += ch;
+    stream.advance();
+  }
+
+  // EOF reached without closing backtick
+  const endPos = stream.getPosition();
+  return factory('TEMPLATE_STRING', value, startPos, endPos);
 }

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -1,8 +1,10 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { TemplateStringReader } from "../../src/lexer/TemplateStringReader.js";
 
-test("TemplateStringReader placeholder", () => {
+test("TemplateStringReader reads template with expression", () => {
   const stream = new CharStream("`template ${expr}`");
-  const token = TemplateStringReader(stream, () => {});
-  expect(token).toBeNull();
+  const token = TemplateStringReader(stream, (type, value, start, end) => new Token(type, value, start, end));
+  expect(token.type).toBe("TEMPLATE_STRING");
+  expect(token.value).toBe("`template ${expr}`");
 });


### PR DESCRIPTION
## Summary
- implement `TemplateStringReader` with basic `${}` support
- test template string tokenization

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f05f265788331aed115642cad73ea