### PR TITLE
Implement WhitespaceReader

### DIFF
--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -1,6 +1,21 @@
-/**
- * TODO(codex): Skip WHITESPACE and attach trivia.
- */
-export function WhitespaceReader(stream, factory) {
-  return null;
+// §4.7 WhitespaceReader
+// Consumes consecutive whitespace characters. When `attachTrivia` is true, a
+// token of type `WHITESPACE` is created using the provided factory. Otherwise
+// the characters are skipped and nothing is returned.
+export function WhitespaceReader(stream, factory, attachTrivia = false) {
+  let ch = stream.current();
+  if (ch === null || !/\s/.test(ch)) return null;
+
+  const start = stream.getPosition();
+  let value = '';
+
+  while (ch !== null && /\s/.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  const end = stream.getPosition();
+
+  return attachTrivia ? factory('WHITESPACE', value, start, end) : null;
 }

--- a/tests/readers/WhitespaceReader.test.js
+++ b/tests/readers/WhitespaceReader.test.js
@@ -1,8 +1,23 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { WhitespaceReader } from "../../src/lexer/WhitespaceReader.js";
 
-test("WhitespaceReader placeholder", () => {
+test("WhitespaceReader skips whitespace", () => {
   const stream = new CharStream("   abc");
   const token = WhitespaceReader(stream, () => {});
   expect(token).toBeNull();
+  expect(stream.getPosition().index).toBe(3);
+  expect(stream.current()).toBe("a");
+});
+
+test("WhitespaceReader can return trivia token", () => {
+  const stream = new CharStream(" \t\n");
+  const token = WhitespaceReader(
+    stream,
+    (t, v, s, e) => new Token(t, v, s, e),
+    true
+  );
+  expect(token.type).toBe("WHITESPACE");
+  expect(token.value).toBe(" \t\n");
+  expect(stream.getPosition().index).toBe(3);
 });


### PR DESCRIPTION
## Summary
- implement whitespace skipping with optional trivia token
- test skipping behaviour and trivia token generation

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f05f2bc4c83319a3dd484cb5b99da