### PR TITLE
Cleanup stale TODO headers

### DIFF
--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -1,13 +1,13 @@
 ### 1. CharStream (§1)
-- [ ] `current()`  
-- [ ] `peek(offset)`  
-- [ ] `advance()`  
-- [ ] `eof()`  
-- [ ] `getPosition()`
+- [x] `current()`
+- [x] `peek(offset)`
+- [x] `advance()`
+- [x] `eof()`
+- [x] `getPosition()`
 
 ### 2. Token (§2)
-- [ ] constructor stores `type`,`value`,`start`,`end`  
-- [ ] `toJSON()`
+- [x] constructor stores `type`,`value`,`start`,`end`
+- [x] `toJSON()`
 
 ### 3. LexerEngine (§3)
 - [ ] initialize `stateStack`  

--- a/src/lexer/CharStream.js
+++ b/src/lexer/CharStream.js
@@ -1,6 +1,7 @@
 /**
- * TODO(codex): Implement CharStream for high-performance JS lexer.
- * - methods: current(), peek(offset), advance(), eof(), getPosition().
+ * A simple utility class for iterating over a string character by
+ * character. Provides helpers to peek ahead, advance the cursor,
+ * check for EOF and retrieve the current position.
  */
 export class CharStream {
   constructor(input) {

--- a/src/lexer/Token.js
+++ b/src/lexer/Token.js
@@ -1,7 +1,7 @@
 /**
- * TODO(codex): Implement Token class.
- * - constructor: type, value, start, end
- * - toJSON(): serialize token
+ * Represents a single lexical token produced by the lexer. Stores the
+ * token type, raw value and positional information. Instances can be
+ * serialized via `toJSON()` for test snapshots or debugging tools.
  */
 export class Token {
   constructor(type, value, start, end) {


### PR DESCRIPTION
## Summary
- remove outdated TODO banner in CharStream
- remove outdated TODO banner in Token
- mark completed items in TODO checklist

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0692cf3083319ac59a9328463a50