### PR TITLE
Implement WhitespaceReader skipping logic

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -23,6 +23,12 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `TemplateStringReader` (§4.6)
 - `WhitespaceReader` (§4.7)
 
+### 4.7 WhitespaceReader
+- Consumes spaces, tabs and newline characters.
+- Advances the `CharStream` for each character so line/column are updated.
+- Returns `null`, but may call `factory('WHITESPACE', text, start, end)` if
+  consumers want to capture trivia.
+
 ## 5. Modes <a name="modes"></a>
 - `default`, `template_string`, `regex`, `jsx`, etc.
 

--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -1,6 +1,21 @@
-/**
- * TODO(codex): Skip WHITESPACE and attach trivia.
- */
+// §4.7 WhitespaceReader
+// Consumes contiguous whitespace characters. The reader always returns null but
+// invokes the provided factory so callers may capture trivia if desired.
 export function WhitespaceReader(stream, factory) {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+  if (ch === null || !/\s/.test(ch)) return null;
+
+  let value = '';
+  while (ch !== null && /\s/.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const endPos = stream.getPosition();
+  if (typeof factory === 'function') {
+    // emit trivia token if consumer wants it
+    factory('WHITESPACE', value, startPos, endPos);
+  }
   return null;
 }

--- a/tests/readers/WhitespaceReader.test.js
+++ b/tests/readers/WhitespaceReader.test.js
@@ -1,8 +1,18 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
 import { WhitespaceReader } from "../../src/lexer/WhitespaceReader.js";
 
-test("WhitespaceReader placeholder", () => {
-  const stream = new CharStream("   abc");
+test("WhitespaceReader skips whitespace and updates position", () => {
+  const stream = new CharStream("  \n\tabc");
   const token = WhitespaceReader(stream, () => {});
   expect(token).toBeNull();
+  // After skipping two spaces, newline and a tab
+  expect(stream.getPosition()).toEqual({ line: 2, column: 1, index: 4 });
+});
+
+test("WhitespaceReader no-op when not at whitespace", () => {
+  const stream = new CharStream("abc");
+  const start = stream.getPosition();
+  const token = WhitespaceReader(stream, () => {});
+  expect(token).toBeNull();
+  expect(stream.getPosition()).toEqual(start);
 });


### PR DESCRIPTION
## Summary
- implement skipping whitespace and emitting trivia token
- document WhitespaceReader behaviour
- test skipping behaviour and position updates

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0695819483318d3a8098eedf1f01