### PR TITLE
Implement TemplateStringReader for template literals

### DIFF
--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -1,6 +1,61 @@
-/**
- * TODO(codex): Read TEMPLATE_STRING tokens with embedded expressions.
- */
+// §4.6 TemplateStringReader
+// Reads template literals delimited by backticks and supporting `${}`
+// interpolation. The returned token value includes the surrounding
+// backticks and all characters contained within.
 export function TemplateStringReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '`') return null;
+
+  let value = '`';
+  // consume opening backtick
+  stream.advance();
+
+  let ch = stream.current();
+  let inExpr = false;
+  let braceDepth = 0;
+
+  while (ch !== null) {
+    if (!inExpr) {
+      if (ch === '`') {
+        value += ch;
+        stream.advance();
+        const endPos = stream.getPosition();
+        return factory('TEMPLATE_STRING', value, startPos, endPos);
+      }
+      if (ch === '\\') {
+        value += ch;
+        stream.advance();
+        ch = stream.current();
+        if (ch !== null) {
+          value += ch;
+          stream.advance();
+        }
+      } else if (ch === '$' && stream.peek() === '{') {
+        value += '${';
+        stream.advance();
+        stream.advance();
+        inExpr = true;
+        braceDepth = 1;
+      } else {
+        value += ch;
+        stream.advance();
+      }
+    } else {
+      if (ch === '{') {
+        braceDepth++;
+      } else if (ch === '}') {
+        braceDepth--;
+        if (braceDepth === 0) {
+          inExpr = false;
+        }
+      }
+      value += ch;
+      stream.advance();
+    }
+    ch = stream.current();
+  }
+
+  // EOF reached without closing backtick
+  const endPos = stream.getPosition();
+  return factory('TEMPLATE_STRING', value, startPos, endPos);
 }

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -1,8 +1,17 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { TemplateStringReader } from "../../src/lexer/TemplateStringReader.js";
 
-test("TemplateStringReader placeholder", () => {
-  const stream = new CharStream("`template ${expr}`");
-  const token = TemplateStringReader(stream, () => {});
-  expect(token).toBeNull();
+test("§4.6 TemplateStringReader: reads template literal with interpolation", () => {
+  const code = "`template ${expr}`";
+  const stream = new CharStream(code + " rest");
+  const token = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("TEMPLATE_STRING");
+  expect(token.value).toBe(code);
+  expect(stream.getPosition().index).toBe(code.length);
+});
+
+test("§4.6 TemplateStringReader: returns null when not at template", () => {
+  const stream = new CharStream("abc");
+  expect(TemplateStringReader(stream, () => {})).toBeNull();
 });


### PR DESCRIPTION
## Summary
- implement parsing of template literals
- add TemplateStringReader unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f06966708833188cb906068c934a3