### PR TITLE
Implement regex vs divide reader

### DIFF
--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -1,6 +1,57 @@
-/**
- * TODO(codex): Read regex literals vs DIVIDE operator.
- */
+// §4.5 RegexOrDivideReader
+// Decide between a regular expression literal like `/abc/g`
+// or the DIVIDE operator `/` based on lookahead.
 export function RegexOrDivideReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '/') return null;
+
+  let offset = 1;
+  let ch = stream.peek(offset);
+
+  // Quick check for cases that cannot be regex: end of file, comment or /=
+  if (ch === null || ch === '/' || ch === '*' || ch === '=') {
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('DIVIDE', '/', startPos, endPos);
+  }
+
+  // Attempt to parse a /pattern/flags sequence
+  let pattern = '';
+  let escaping = false;
+  while ((ch = stream.peek(offset)) !== null) {
+    if (!escaping && ch === '/') {
+      break; // end of pattern
+    }
+    pattern += ch;
+    if (!escaping && ch === '\\') {
+      escaping = true;
+    } else {
+      escaping = false;
+    }
+    offset++;
+  }
+
+  // If no closing slash found, treat as DIVIDE
+  if (ch !== '/') {
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('DIVIDE', '/', startPos, endPos);
+  }
+
+  // Include closing slash
+  offset++;
+  let flags = '';
+  ch = stream.peek(offset);
+  while (ch !== null && /[a-z]/i.test(ch)) {
+    flags += ch;
+    offset++;
+    ch = stream.peek(offset);
+  }
+
+  // Consume all characters of the regex literal
+  const length = offset;
+  for (let i = 0; i < length; i++) stream.advance();
+  const endPos = stream.getPosition();
+  const value = `/${pattern}/${flags}`;
+  return factory('REGEX', value, startPos, endPos);
 }

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -1,8 +1,19 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { RegexOrDivideReader } from "../../src/lexer/RegexOrDivideReader.js";
 
-test("RegexOrDivideReader placeholder", () => {
-  const stream = new CharStream("/abc/");
-  const token = RegexOrDivideReader(stream, () => {});
-  expect(token).toBeNull();
+test("reads regex literal", () => {
+  const stream = new CharStream("/abc/g");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/abc/g");
+  expect(stream.current()).toBe(null);
+});
+
+test("reads divide operator", () => {
+  const stream = new CharStream("/ x");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("DIVIDE");
+  expect(token.value).toBe("/");
+  expect(stream.current()).toBe(" ");
 });


### PR DESCRIPTION
## Summary
- implement RegexOrDivideReader to parse `/pattern/flags` or `/`
- add unit tests for regex literals and divide operator

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f06971d1083318d2db6e37858ae34