### PR TITLE
Implement regex vs divide reader

### DIFF
--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -1,6 +1,30 @@
-/**
- * TODO(codex): Read regex literals vs DIVIDE operator.
- */
+// §4.5 RegexOrDivideReader
+// Decide between a regular expression literal like `/abc/g`
+// or the DIVIDE operator `/` based solely on lookahead.
 export function RegexOrDivideReader(stream, factory) {
-  return null;
+  const startPos = stream.getPosition();
+  if (stream.current() !== '/') return null;
+
+  const rest = stream.input.slice(stream.index);
+
+  // Negative lookahead for comment or /=
+  if (rest.startsWith('//') || rest.startsWith('/*') || rest.startsWith('/=')) {
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('DIVIDE', '/', startPos, endPos);
+  }
+
+  // Try to match a regex literal `/pattern/flags` using a regular expression
+  const match = rest.match(/^\/(?:\\.|[^\\\/\n])+\/[a-z]*/);
+  if (match) {
+    const value = match[0];
+    for (let i = 0; i < value.length; i++) stream.advance();
+    const endPos = stream.getPosition();
+    return factory('REGEX', value, startPos, endPos);
+  }
+
+  // Fallback: treat as DIVIDE
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('DIVIDE', '/', startPos, endPos);
 }

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -1,8 +1,33 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { RegexOrDivideReader } from "../../src/lexer/RegexOrDivideReader.js";
 
-test("RegexOrDivideReader placeholder", () => {
-  const stream = new CharStream("/abc/");
-  const token = RegexOrDivideReader(stream, () => {});
-  expect(token).toBeNull();
+test("§4.5 reads regex literal", () => {
+  const stream = new CharStream("/abc/g");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/abc/g");
+  expect(stream.current()).toBe(null);
+});
+
+test("§4.5 reads regex with escaped slash", () => {
+  const stream = new CharStream("/a\\/b/i");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/a\\/b/i");
+});
+
+test("§4.5 reads divide operator", () => {
+  const stream = new CharStream("/ x");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("DIVIDE");
+  expect(token.value).toBe("/");
+  expect(stream.current()).toBe(" ");
+});
+
+test("§4.5 divide before comment", () => {
+  const stream = new CharStream("// comment");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("DIVIDE");
+  expect(stream.current()).toBe("/");
 });


### PR DESCRIPTION
## Summary
- implement RegexOrDivideReader to differentiate `/pattern/flags` from `/`
- expand unit tests for regex literals and divide operator cases

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f06971d1083318d2db6e37858ae34