### PR TITLE
Implement TemplateStringReader and adjust Jest config

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,5 @@
 module.exports = {
   testEnvironment: 'node',
-  // Tell Jest to treat .js files as ESM
-  extensionsToTreatAsEsm: ['.js'],
   // Don’t transform, we’re native ESM
   transform: {},
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf dist coverage",
     "build": "npm run clean && babel src --out-dir dist",
     "lint": "eslint . --fix",
-    "test": "jest --config jest.config.cjs --coverage",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
     "release": "semantic-release"
   },
   "repository": {

--- a/src/lexer/CharStream.js
+++ b/src/lexer/CharStream.js
@@ -18,4 +18,9 @@ export class CharStream {
   }
   eof() { return this.index >= this.input.length; }
   getPosition() { return { line: this.line, column: this.column, index: this.index }; }
+  setPosition(pos) {
+    this.index = pos.index;
+    this.line = pos.line;
+    this.column = pos.column;
+  }
 }

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -4,6 +4,13 @@ export function RegexOrDivideReader(stream, factory) {
   const startPos = stream.getPosition();
   if (stream.current() !== '/') return null;
 
+  // '/=' is always an operator
+  if (stream.peek() === '=') {
+    stream.advance();
+    stream.advance();
+    return factory('OPERATOR', '/=', startPos, stream.getPosition());
+  }
+
   // Look backwards for the last non-whitespace character to guess context.
   let i = stream.getPosition().index - 1;
   let prev = null;

--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -1,74 +1,78 @@
-// §4.5 RegexOrDivideReader
-// Context‐sensitive reader: decides whether a “/” starts a RegExp literal or is a divide operator.
-export function RegexOrDivideReader(stream, factory) {
+// §4.6 TemplateStringReader
+// Reads JavaScript template literals enclosed by backticks including
+// embedded `${}` expressions. Returns a `TEMPLATE_STRING` token with the
+// full raw value or `null` if the stream is not positioned at a backtick.
+export function TemplateStringReader(stream, factory) {
   const startPos = stream.getPosition();
-  if (stream.current() !== '/') return null;
+  if (stream.current() !== '`') return null;
 
-  // Look backwards for the last non-whitespace character to guess context.
-  let i = stream.getPosition().index - 1;
-  let prev = null;
-  while (i >= 0) {
-    const ch = stream.input[i];
-    if (/\s/.test(ch)) {
-      i--;
-      continue;
-    }
-    prev = ch;
-    break;
-  }
+  let value = '';
+  // consume opening backtick
+  value += '`';
+  stream.advance();
 
-  // Tokens that typically allow a regex literal to follow:
-  const regexStarters = new Set([
-    '(', '{', '[', '=', ':', ',', ';', '!', '?', '+', '-', '*', '%', '&', '|',
-    '^', '~', '<', '>'
-  ]);
-  const isRegexContext = prev === null || regexStarters.has(prev);
-
-  if (!isRegexContext) {
-    // It's a divide operator (or '/=')
-    stream.advance();
-    if (stream.current() === '=') {
-      stream.advance();
-      return factory('OPERATOR', '/=', startPos, stream.getPosition());
-    }
-    return factory('OPERATOR', '/', startPos, stream.getPosition());
-  }
-
-  // Parse a regex literal `/pattern/flags`
-  stream.advance(); // consume opening `/`
-
-  let body = '';
-  let escaped = false;
   while (!stream.eof()) {
     const ch = stream.current();
-    if (!escaped && ch === '/') break;
-    if (!escaped && ch === '\\') {
-      escaped = true;
-      body += ch;
+
+    // handle escape sequences
+    if (ch === '\\') {
+      value += ch;
       stream.advance();
+      if (!stream.eof()) {
+        value += stream.current();
+        stream.advance();
+      }
       continue;
     }
-    escaped = false;
-    body += ch;
+
+    // end of template literal
+    if (ch === '`') {
+      value += ch;
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('TEMPLATE_STRING', value, startPos, endPos);
+    }
+
+    // embedded expression `${ ... }`
+    if (ch === '$' && stream.peek() === '{') {
+      value += '${';
+      stream.advance();
+      stream.advance();
+
+      // simple brace matching for the expression body
+      let depth = 1;
+      while (!stream.eof() && depth > 0) {
+        const c = stream.current();
+        if (c === '\\') {
+          value += c;
+          stream.advance();
+          if (!stream.eof()) {
+            value += stream.current();
+            stream.advance();
+          }
+          continue;
+        }
+        if (c === '{') depth++;
+        if (c === '}') depth--;
+        value += c;
+        stream.advance();
+        if (depth === 0) break;
+      }
+      continue;
+    }
+
+    // regular character within template
+    value += ch;
     stream.advance();
   }
 
-  if (stream.current() !== '/') {
-    // Unterminated regex — back out and let another reader handle it
+  // Unterminated template literal – reset position and return null
+  if (typeof stream.setPosition === 'function') {
     stream.setPosition(startPos);
-    return null;
+  } else {
+    stream.index = startPos.index;
+    stream.line = startPos.line;
+    stream.column = startPos.column;
   }
-
-  stream.advance(); // consume closing `/`
-
-  // Collect flags
-  let flags = '';
-  while (!stream.eof() && /[a-z]/i.test(stream.current())) {
-    flags += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  const value = `/${body}/${flags}`;
-  return factory('REGEX', value, startPos, endPos);
+  return null;
 }


### PR DESCRIPTION
## Summary
- add `setPosition` to `CharStream`
- detect '/=' early in `RegexOrDivideReader`
- implement a proper `TemplateStringReader`
- simplify Jest config and run with `--experimental-vm-modules`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d05c80a083319ef44b536cce60fa