### PR TITLE
Remove missing setup script references

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
   },
   "workspaceFolder": "/workspace",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-  "postCreateCommand": ".github/scripts/setup.sh",
   "remoteUser": "node",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: 18.x
           cache: npm
 
-      - name: Bootstrap project
-        run: bash ./.github/scripts/setup.sh
 
       - name: Publish release
         env:


### PR DESCRIPTION
## Summary
- remove references to `.github/scripts/setup.sh` from release workflow and devcontainer configuration

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: No matching version found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3e267a48331b3e0d7d2a863b5b1