### PR TITLE
Add StringReader for quoted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ Please read `CODE_OF_CONDUCT.md` to understand expectations for participation.
 ## Changelog
 
 All notable changes are tracked in `CHANGELOG.md`.
+
+## Example
+
+Tokenizing a quoted string emits a `STRING` token:
+
+```js
+import { tokenize } from './index.js';
+console.log(tokenize("'hello'").map(t => t.type));
+// => ['STRING']
+```

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -20,6 +20,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `OperatorReader` (§4.3)
 - `PunctuationReader` (§4.4)
 - `RegexOrDivideReader` (§4.5)
+- `StringReader` (§4.6a)
 - `TemplateStringReader` (§4.6)
 - `WhitespaceReader` (§4.7)
 
@@ -27,7 +28,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `default`, `template_string`, `regex`, `jsx`, etc.
 
 ## 6. Token Format <a name="format"></a>
-- `type`: `IDENTIFIER`, `NUMBER`, …  
+- `type`: `IDENTIFIER`, `NUMBER`, `STRING`, …
 - `value`: lexeme  
 - `start`/`end`: `{ line, column, index }`  
 - `raw`: original text (optional)  

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -3,6 +3,7 @@ import { NumberReader } from './NumberReader.js';
 import { OperatorReader } from './OperatorReader.js';
 import { PunctuationReader } from './PunctuationReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
+import { StringReader } from './StringReader.js';
 import { TemplateStringReader } from './TemplateStringReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
 import { Token } from './Token.js';
@@ -23,6 +24,7 @@ export class LexerEngine {
         OperatorReader,
         PunctuationReader,
         RegexOrDivideReader,
+        StringReader,
         TemplateStringReader
       ],
       template_string: [TemplateStringReader],

--- a/src/lexer/StringReader.js
+++ b/src/lexer/StringReader.js
@@ -1,0 +1,43 @@
+// \u00a7 4.6 StringReader
+// Parses single and double quoted string literals with escape support.
+export function StringReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const quote = stream.current();
+  if (quote !== '"' && quote !== "'") return null;
+
+  let value = quote;
+  stream.advance();
+  let escaped = false;
+
+  while (!stream.eof()) {
+    const ch = stream.current();
+
+    value += ch;
+    stream.advance();
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (ch === quote) {
+      const endPos = stream.getPosition();
+      return factory('STRING', value, startPos, endPos);
+    }
+
+    if (ch === '\n' || ch === '\r') {
+      // Unterminated string literal
+      stream.setPosition(startPos);
+      return null;
+    }
+  }
+
+  // EOF before closing quote
+  stream.setPosition(startPos);
+  return null;
+}

--- a/tests/readers/StringReader.test.js
+++ b/tests/readers/StringReader.test.js
@@ -1,0 +1,30 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { StringReader } from "../../src/lexer/StringReader.js";
+
+test("StringReader reads quoted strings", () => {
+  const stream = new CharStream("'abc' \"def\"");
+  let token = StringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("STRING");
+  expect(token.value).toBe("'abc'");
+  stream.advance(); // skip space
+  token = StringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("STRING");
+  expect(token.value).toBe('"def"');
+});
+
+test("StringReader handles escape sequences", () => {
+  const src = "\"a\\n\"";
+  const stream = new CharStream(src);
+  const token = StringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.value).toBe(src);
+  expect(token.type).toBe("STRING");
+  expect(stream.getPosition().index).toBe(src.length);
+});
+
+test("StringReader returns null for unterminated", () => {
+  const stream = new CharStream("'oops");
+  const token = StringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token).toBeNull();
+  expect(stream.getPosition().index).toBe(0);
+});


### PR DESCRIPTION
## Summary
- implement `StringReader` for `'` and `"` strings
- register reader in `LexerEngine`
- document `STRING` token in README and lexer spec
- add unit tests for `StringReader`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851dae8554083319d7506e0009ab92f