### PR TITLE
Support extended number syntax

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -23,6 +23,10 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `TemplateStringReader` (§4.6)
 - `WhitespaceReader` (§4.7)
 
+`NumberReader` supports decimal numbers with optional fractional and exponent
+parts as well as binary (`0b`), octal (`0o`), and hexadecimal (`0x`) literals.
+Numeric separators (`_`) are permitted between digits.
+
 ## 5. Modes <a name="modes"></a>
 - `default`, `template_string`, `regex`, `jsx`, etc.
 

--- a/src/lexer/NumberReader.js
+++ b/src/lexer/NumberReader.js
@@ -4,24 +4,87 @@ export function NumberReader(stream, factory) {
   let ch = stream.current();
   if (!/\d/.test(ch)) return null;
 
-  let value = '';
-  // integer part
-  while (ch !== null && /\d/.test(ch)) {
-    value += ch;
-    stream.advance();
-    ch = stream.current();
+  function readDigits(regex) {
+    let result = '';
+    let c = stream.current();
+    if (c === '_' || c === null || !regex.test(c)) return null;
+    while (c !== null && (regex.test(c) || c === '_')) {
+      if (c === '_') {
+        if (result === '' || result[result.length - 1] === '_' || !regex.test(stream.peek())) {
+          return null;
+        }
+      }
+      result += c;
+      stream.advance();
+      c = stream.current();
+    }
+    if (result.endsWith('_')) return null;
+    return result;
   }
-  // optional decimal
+
+  let value = '';
+
+  if (ch === '0') {
+    const next = stream.peek();
+    if (next === 'x' || next === 'X') {
+      value = '0' + next;
+      stream.advance();
+      stream.advance();
+      const digits = readDigits(/[0-9a-fA-F]/);
+      if (digits === null) { stream.setPosition(startPos); return null; }
+      value += digits;
+      const endPos = stream.getPosition();
+      return factory('NUMBER', value, startPos, endPos);
+    }
+    if (next === 'o' || next === 'O') {
+      value = '0' + next;
+      stream.advance();
+      stream.advance();
+      const digits = readDigits(/[0-7]/);
+      if (digits === null) { stream.setPosition(startPos); return null; }
+      value += digits;
+      const endPos = stream.getPosition();
+      return factory('NUMBER', value, startPos, endPos);
+    }
+    if (next === 'b' || next === 'B') {
+      value = '0' + next;
+      stream.advance();
+      stream.advance();
+      const digits = readDigits(/[01]/);
+      if (digits === null) { stream.setPosition(startPos); return null; }
+      value += digits;
+      const endPos = stream.getPosition();
+      return factory('NUMBER', value, startPos, endPos);
+    }
+  }
+
+  const intPart = readDigits(/\d/);
+  if (intPart === null) { stream.setPosition(startPos); return null; }
+  value += intPart;
+
+  ch = stream.current();
   if (ch === '.') {
     value += '.';
     stream.advance();
+    const frac = readDigits(/\d/);
+    if (frac === null) { stream.setPosition(startPos); return null; }
+    value += frac;
     ch = stream.current();
-    while (ch !== null && /\d/.test(ch)) {
+  }
+
+  if (ch === 'e' || ch === 'E') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+    if (ch === '+' || ch === '-') {
       value += ch;
       stream.advance();
-      ch = stream.current();
     }
+    const exp = readDigits(/\d/);
+    if (exp === null) { stream.setPosition(startPos); return null; }
+    value += exp;
   }
+
   const endPos = stream.getPosition();
   return factory('NUMBER', value, startPos, endPos);
 }

--- a/tests/readers/NumberReader.test.js
+++ b/tests/readers/NumberReader.test.js
@@ -3,12 +3,42 @@ import { Token } from "../../src/lexer/Token.js";
 import { NumberReader } from "../../src/lexer/NumberReader.js";
 
 test("NumberReader reads integer and decimal", () => {
-  let stream = new CharStream("123 456.78");
-  let token = NumberReader(stream, (type, value, start, end) => new Token(type, value, start, end));
+  const stream = new CharStream("123 456.78");
+  let token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
   expect(token.type).toBe("NUMBER");
   expect(token.value).toBe("123");
-  stream.advance(); // skip space
-  token = NumberReader(stream, (type, value, start, end) => new Token(type, value, start, end));
+  stream.advance();
+  token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
   expect(token.type).toBe("NUMBER");
   expect(token.value).toBe("456.78");
+});
+
+test("NumberReader handles hex, octal, binary, exponent and underscores", () => {
+  const cases = [
+    { src: "0x1f", value: "0x1f" },
+    { src: "0o10", value: "0o10" },
+    { src: "0b1010", value: "0b1010" },
+    { src: "1e4", value: "1e4" },
+    { src: "1_000", value: "1_000" },
+    { src: "123_456.78", value: "123_456.78" },
+    { src: "6.02e23", value: "6.02e23" },
+    { src: "0xFF_A0", value: "0xFF_A0" }
+  ];
+
+  for (const c of cases) {
+    const stream = new CharStream(c.src);
+    const token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+    expect(token.type).toBe("NUMBER");
+    expect(token.value).toBe(c.value);
+    expect(stream.getPosition().index).toBe(c.src.length);
+  }
+});
+
+test("NumberReader returns null for invalid literals", () => {
+  const invalid = ["0x", "0b102", "1__0", "1_", "1e", "1e-"];
+  for (const src of invalid) {
+    const stream = new CharStream(src);
+    const token = NumberReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+    expect(token).toBeNull();
+  }
 });


### PR DESCRIPTION
## Summary
- allow parsing of hex, octal, binary and exponent numeric literals
- permit underscore separators
- document all accepted numeric forms
- broaden NumberReader tests for new formats and invalid examples

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: No matching version found for @babel/cli@^7.27.4)*

------
https://chatgpt.com/codex/tasks/task_e_6851daec0bfc83318b4915432c63c2ce