### PR TITLE
Add lexer benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Please read `CODE_OF_CONDUCT.md` to understand expectations for participation.
 ## Changelog
 
 All notable changes are tracked in `CHANGELOG.md`.
+
+## Benchmarks
+
+Measure lexing throughput on the sample files in `tests/fixtures`:
+
+```bash
+node tests/benchmarks/lexer.bench.js
+```

--- a/tests/benchmarks/lexer.bench.js
+++ b/tests/benchmarks/lexer.bench.js
@@ -1,0 +1,29 @@
+import { dirname, join, basename } from 'path';
+import { fileURLToPath } from 'url';
+import { readdirSync, readFileSync } from 'fs';
+import { tokenize } from '../../index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function benchmark(filePath, iterations = 50) {
+  const code = readFileSync(filePath, 'utf8');
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) {
+    tokenize(code);
+  }
+  const durationNs = Number(process.hrtime.bigint() - start);
+  const seconds = durationNs / 1e9;
+  const bytes = Buffer.byteLength(code) * iterations;
+  const mbps = bytes / (1024 * 1024) / seconds;
+  console.log(`${basename(filePath)}: ${mbps.toFixed(2)} MB/s`);
+}
+
+(function main() {
+  const fixtureDir = join(__dirname, '..', 'fixtures');
+  const files = readdirSync(fixtureDir).filter(f => f.endsWith('.js'));
+  if (files.length === 0) {
+    console.error('No fixture files found in tests/fixtures');
+    process.exit(1);
+  }
+  files.forEach(f => benchmark(join(fixtureDir, f)));
+})();

--- a/tests/fixtures/lexer_engine.js
+++ b/tests/fixtures/lexer_engine.js
@@ -1,0 +1,87 @@
+import { IdentifierReader } from './IdentifierReader.js';
+import { NumberReader } from './NumberReader.js';
+import { OperatorReader } from './OperatorReader.js';
+import { PunctuationReader } from './PunctuationReader.js';
+import { RegexOrDivideReader } from './RegexOrDivideReader.js';
+import { TemplateStringReader } from './TemplateStringReader.js';
+import { WhitespaceReader } from './WhitespaceReader.js';
+import { Token } from './Token.js';
+import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
+
+/**
+ * LexerEngine orchestrates all token readers to produce a stream of Tokens.
+ */
+export class LexerEngine {
+  constructor(stream) {
+    this.stream = stream;
+    this.stateStack = ['default'];
+    // Mapping of mode -> reader list. Order determines priority.
+    this.modes = {
+      default: [
+        IdentifierReader,
+        NumberReader,
+        OperatorReader,
+        PunctuationReader,
+        RegexOrDivideReader,
+        TemplateStringReader
+      ],
+      template_string: [TemplateStringReader],
+      regex: [RegexOrDivideReader]
+    };
+    // Track last returned token for contextual readers
+    this.lastToken = null;
+  }
+
+  currentMode() {
+    return this.stateStack[this.stateStack.length - 1];
+  }
+
+  pushMode(mode) {
+    this.stateStack.push(mode);
+  }
+
+  popMode() {
+    if (this.stateStack.length > 1) {
+      this.stateStack.pop();
+    }
+  }
+
+  /**
+   * Reads the next token from the stream, or returns null at EOF.
+   */
+  nextToken() {
+    const { stream } = this;
+    const factory = (type, value, start, end) => new Token(type, value, start, end);
+
+    while (!stream.eof()) {
+      // 1. Skip whitespace (and collect as trivia internally, if desired)
+      WhitespaceReader(stream, factory, this);
+      if (stream.eof()) break;
+
+      const mode = this.currentMode();
+      const readers = this.modes[mode] || this.modes.default;
+
+      // 2. Try each reader in sequence for the current mode
+      for (const Reader of readers) {
+        const token = Reader(stream, factory, this);
+        if (token) {
+          // 3. Promote identifiers that match keywords
+          if (
+            token.type === 'IDENTIFIER' &&
+            JavaScriptGrammar.keywords.includes(token.value)
+          ) {
+            token.type = 'KEYWORD';
+          }
+          this.lastToken = token;
+          return token;
+        }
+      }
+
+      // 4. If nothing matched, advance one character to avoid infinite loops
+      stream.advance();
+    }
+
+    // End of file
+    return null;
+  }
+}

--- a/tests/fixtures/template_string_reader.js
+++ b/tests/fixtures/template_string_reader.js
@@ -1,0 +1,79 @@
+// §4.6 TemplateStringReader
+// Reads JavaScript template literals enclosed by backticks, including
+// embedded `${}` expressions. Returns a TEMPLATE_STRING token with the
+// full raw value or null if the stream isn’t at a backtick.
+export function TemplateStringReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '`') return null;
+
+  let value = '';
+  // consume opening backtick
+  value += '`';
+  stream.advance();
+
+  while (!stream.eof()) {
+    const ch = stream.current();
+
+    // handle escape sequences
+    if (ch === '\\') {
+      value += ch;
+      stream.advance();
+      if (!stream.eof()) {
+        value += stream.current();
+        stream.advance();
+      }
+      continue;
+    }
+
+    // end of template literal
+    if (ch === '`') {
+      value += '`';
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('TEMPLATE_STRING', value, startPos, endPos);
+    }
+
+    // embedded expression `${ ... }`
+    if (ch === '$' && stream.peek() === '{') {
+      value += '${';
+      stream.advance(); // consume '$'
+      stream.advance(); // consume '{'
+
+      // match braces within the expression
+      let depth = 1;
+      while (!stream.eof() && depth > 0) {
+        const c = stream.current();
+        if (c === '\\') {
+          // preserve escaped char inside expression
+          value += c;
+          stream.advance();
+          if (!stream.eof()) {
+            value += stream.current();
+            stream.advance();
+          }
+          continue;
+        }
+        if (c === '{') depth++;
+        else if (c === '}') depth--;
+        value += c;
+        stream.advance();
+      }
+      continue;
+    }
+
+    // regular template content
+    value += ch;
+    stream.advance();
+  }
+
+  // Unterminated literal — reset and bail out
+  if (typeof stream.setPosition === 'function') {
+    stream.setPosition(startPos);
+  } else {
+    // fallback if no setPosition API
+    stream.index  = startPos.index;
+    stream.line   = startPos.line;
+    stream.column = startPos.column;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add benchmark runner measuring lexing throughput
- include sample fixture JS files
- document how to run benchmarks

## Testing
- `node tests/benchmarks/lexer.bench.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851daf231e08331a6660fb37a63645d