### PR TITLE
Add comment/string token samples to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Document sample token streams with comments and strings
+- Show CLI usage snippet in README
 - Project scaffold for experimental-js-lexer
 - Spec, tests, CI, lint, promptMap, issue templates
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ A modular, adaptive, experimental JavaScript lexer designed for autonomous devel
 
 See `QUICK_START.md` for setup and development guidelines.
 
+### CLI Example
+
+Tokenize a snippet containing comments and a template string:
+
+```bash
+node index.js "/* greeting */ let msg = `hi`; // end" --verbose
+```
+
+Outputs
+
+```
+Token { type: 'COMMENT', value: '/* greeting */', ... }
+Token { type: 'KEYWORD', value: 'let', ... }
+Token { type: 'IDENTIFIER', value: 'msg', ... }
+Token { type: 'OPERATOR', value: '=', ... }
+Token { type: 'TEMPLATE_STRING', value: '`hi`', ... }
+Token { type: 'PUNCTUATION', value: ';', ... }
+Token { type: 'COMMENT', value: '// end', ... }
+[
+  ...
+]
+```
+
 ## Project Board
 
 Track progress and self-assign tasks on the [GitHub Project Board](https://github.com/your-org/experimental-js-lexer/projects/1).

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -3,7 +3,7 @@
 This document defines the architecture and requirements for the experimental JavaScript lexer.
 
 ## 1. CharStream <a name="charstream"></a>
-- Provides character-level access  
+- Provides character-level access
 - Methods: `current()`, `peek(offset)`, `advance()`, `eof()`, `getPosition()`
 
 ## 2. Token <a name="token"></a>
@@ -27,24 +27,46 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `default`, `template_string`, `regex`, `jsx`, etc.
 
 ## 6. Token Format <a name="format"></a>
-- `type`: `IDENTIFIER`, `NUMBER`, …  
-- `value`: lexeme  
-- `start`/`end`: `{ line, column, index }`  
-- `raw`: original text (optional)  
-- `trivia`: leading/trailing comments/whitespace  
+- `type`: `IDENTIFIER`, `NUMBER`, …
+- `value`: lexeme
+- `start`/`end`: `{ line, column, index }`
+- `raw`: original text (optional)
+- `trivia`: leading/trailing comments/whitespace
+
+### Example Token Stream
+
+Input:
+
+```js
+/* start */ let msg = `hi`; // end
+```
+
+Results in tokens roughly like:
+
+```json
+[
+  { "type": "COMMENT", "value": "/* start */" },
+  { "type": "KEYWORD", "value": "let" },
+  { "type": "IDENTIFIER", "value": "msg" },
+  { "type": "OPERATOR", "value": "=" },
+  { "type": "TEMPLATE_STRING", "value": "`hi`" },
+  { "type": "PUNCTUATION", "value": ";" },
+  { "type": "COMMENT", "value": "// end" }
+]
+```
 
 ## 7. Performance Targets <a name="perf"></a>
-- Startup < 5 ms (< 1 k lines)  
-- Full-file ≤ 100 ms (100 k lines)  
-- Support lookahead & incremental lex  
+- Startup < 5 ms (< 1 k lines)
+- Full-file ≤ 100 ms (100 k lines)
+- Support lookahead & incremental lex
 
 ## 8. Testing & CI <a name="ci"></a>
-- Unit tests: `tests/readers/*.test.js`  
-- Integration tests: `tests/integration.test.js`  
-- ESLint rules + JSDoc  
-- Jest coverage ≥ 90%  
-- GitHub Actions CI  
+- Unit tests: `tests/readers/*.test.js`
+- Integration tests: `tests/integration.test.js`
+- ESLint rules + JSDoc
+- Jest coverage ≥ 90%
+- GitHub Actions CI
 
 ## 9. Extensibility <a name="ext"></a>
-- Grammar definitions: `src/grammar/JavaScriptGrammar.js`  
+- Grammar definitions: `src/grammar/JavaScriptGrammar.js`
 - Agent prompts: `.codex/promptMap.json`


### PR DESCRIPTION
## Summary
- document example token stream including comments and strings
- show CLI example in `README.md`
- log additions in `CHANGELOG.md`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851daf329248331a152e81a8b973787