### PR TITLE
Update auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,23 +1,39 @@
 # .github/workflows/auto-merge.yml
 name: Auto-Merge Reader PRs
 on:
-  pull_request:
-    types: [labeled, synchronize]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
   enable-automerge:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'reader') &&
-      github.event.pull_request.mergeable_state == 'clean'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
           script: |
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              merge_method: 'squash'
+            const pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              core.info('No pull request associated with this workflow run.');
+              return;
+            }
+            const { data } = await github.rest.pulls.get({
+              owner: pr.base.repo.owner.login,
+              repo: pr.base.repo.name,
+              pull_number: pr.number,
             });
+            if (data.labels.some(l => l.name === 'reader') && data.mergeable_state === 'clean') {
+              await github.rest.pulls.merge({
+                owner: pr.base.repo.owner.login,
+                repo: pr.base.repo.name,
+                pull_number: pr.number,
+                merge_method: 'squash'
+              });
+            } else {
+              core.info('PR not ready for auto-merge.');
+            }


### PR DESCRIPTION
## Summary
- ensure `auto-merge.yml` only runs after CI succeeds
- use a PAT for write access when merging PRs

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: no matching version found for @babel/cli@^7.27.4)*

------
https://chatgpt.com/codex/tasks/task_e_6851dfeae9e08331af2c4a6fa6854e04