### PR TITLE
Use robust automerge action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,14 +10,12 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'reader') &&
       github.event.pull_request.mergeable_state == 'clean'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - name: Enable Pull Request Automerge
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              merge_method: 'squash'
-            });
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- replace manual merge GitHub Script with `peter-evans/enable-pull-request-automerge`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: No matching version found for @babel/cli@^7.27.4)*

------
https://chatgpt.com/codex/tasks/task_e_6851dffe23788331a5a76053ad295548