### PR TITLE
Fix identifier and regex parsing

### DIFF
--- a/src/lexer/IdentifierReader.js
+++ b/src/lexer/IdentifierReader.js
@@ -3,7 +3,7 @@
 export function IdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
-  if (!/[A-Za-z_]/.test(ch)) return null;
+  if (ch === null || !/[A-Za-z_]/.test(ch)) return null;
 
   let value = '';
   while (ch !== null && /[A-Za-z0-9_]/.test(ch)) {

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -24,9 +24,9 @@ export class LexerEngine {
         WhitespaceReader,
         IdentifierReader,
         NumberReader,
+        RegexOrDivideReader,
         OperatorReader,
         PunctuationReader,
-        RegexOrDivideReader,
         TemplateStringReader
       ],
       template_string: [TemplateStringReader],


### PR DESCRIPTION
## Summary
- fix IdentifierReader to handle null at EOF
- adjust reader order so regex literals are detected before operator tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e3a835e48331b7f4d0b25f2e2af5