### PR TITLE
Fix CI workflow artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload coverage report
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.node-version }}
           path: coverage/


### PR DESCRIPTION
## Summary
- update deprecated `actions/upload-artifact` to `v4`

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6851e903b2208331800bd70a000745aa