### PR TITLE
Improve test coverage, add CLI tests

### DIFF
--- a/src/lexer/CharStream.js
+++ b/src/lexer/CharStream.js
@@ -1,6 +1,5 @@
 /**
- * TODO(codex): Implement CharStream for high-performance JS lexer.
- * - methods: current(), peek(offset), advance(), eof(), getPosition().
+ * Provides character level access with position tracking for the lexer.
  */
 export class CharStream {
   constructor(input) {

--- a/src/lexer/Token.js
+++ b/src/lexer/Token.js
@@ -1,7 +1,5 @@
 /**
- * TODO(codex): Implement Token class.
- * - constructor: type, value, start, end
- * - toJSON(): serialize token
+ * Represents a single lexical token produced by the lexer.
  */
 export class Token {
   constructor(type, value, start, end) {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
+
+/**
+ * Helper to execute the CLI entry with mocked process args.
+ * @param {string[]} args
+ */
+async function runCli(args) {
+  jest.resetModules();
+  const cliPath = fileURLToPath(new URL('../index.js', import.meta.url));
+  const originalArgv = process.argv.slice();
+  process.argv = [process.execPath, cliPath, ...args];
+  const logs = [];
+  const errors = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (msg) => logs.push(msg);
+  console.error = (msg) => errors.push(msg);
+  let exitCode;
+  const originalExit = process.exit;
+  process.exit = (code) => { exitCode = code; };
+  await import('../index.js');
+  console.log = originalLog;
+  console.error = originalError;
+  process.exit = originalExit;
+  process.argv = originalArgv;
+  return { logs, errors, exitCode };
+}
+
+test('CLI prints tokens array for valid input', async () => {
+  const result = await runCli(['let x=1;']);
+  expect(Array.isArray(result.logs[0])).toBe(true);
+  expect(result.logs[0].map(t => t.type)).toEqual([
+    'KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION'
+  ]);
+  expect(result.exitCode).toBeUndefined();
+});
+
+test('CLI exits with code 1 on lexer error', async () => {
+  const result = await runCli(['/abc']);
+  expect(result.exitCode).toBe(1);
+  expect(result.errors.length).toBeGreaterThan(0);
+});

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -1,0 +1,11 @@
+import { CharStream } from "../src/lexer/CharStream.js";
+import { LexerEngine } from "../src/lexer/LexerEngine.js";
+
+test("LexerEngine pushMode and popMode manage state stack", () => {
+  const engine = new LexerEngine(new CharStream(""));
+  expect(engine.currentMode()).toBe("default");
+  engine.pushMode("template_string");
+  expect(engine.currentMode()).toBe("template_string");
+  engine.popMode();
+  expect(engine.currentMode()).toBe("default");
+});

--- a/tests/readers/CharStream.test.js
+++ b/tests/readers/CharStream.test.js
@@ -21,3 +21,14 @@ test("CharStream advance updates line and column across newlines", () => {
   stream.advance();
   expect(stream.getPosition()).toEqual({ line: 3, column: 0, index: 4 });
 });
+
+test("CharStream setPosition restores previous position", () => {
+  const stream = new CharStream("abc");
+  stream.advance();
+  stream.advance();
+  const pos = stream.getPosition();
+  stream.advance();
+  expect(stream.getPosition().index).toBe(3);
+  stream.setPosition(pos);
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -45,3 +45,25 @@ test("TemplateStringReader returns LexerError on bad escape", () => {
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('BadEscape');
 });
+
+test("TemplateStringReader handles escapes and nested braces", () => {
+  const src = "`a ${b\\} c}`";
+  const stream = new CharStream(src);
+  const token = TemplateStringReader(
+    stream,
+    (t, v, s, e) => new Token(t, v, s, e)
+  );
+  expect(token.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});
+
+test("TemplateStringReader tracks nested braces", () => {
+  const src = "`t ${ {a:{b}} } end`";
+  const stream = new CharStream(src);
+  const token = TemplateStringReader(
+    stream,
+    (t, v, s, e) => new Token(t, v, s, e)
+  );
+  expect(token.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});


### PR DESCRIPTION
## Summary
- clean up documentation comments in CharStream and Token
- add CLI test helpers and coverage
- cover LexerEngine push/pop mode
- test CharStream setPosition
- expand TemplateStringReader tests

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ea114b5083318d190ba6595806cc