### PR TITLE
Fix lint warnings in WhitespaceReader

### DIFF
--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -3,10 +3,8 @@
  * Consumes consecutive whitespace characters.
  * Does not emit a token; callers may attach trivia if needed.
  */
-export function WhitespaceReader(stream, factory) {
-  let consumed = false;
+export function WhitespaceReader(stream) {
   while (!stream.eof() && /\s/.test(stream.current())) {
-    consumed = true;
     stream.advance();
   }
   // No token is returned for whitespace.


### PR DESCRIPTION
## Summary
- remove unused parameters in `WhitespaceReader`

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6851ee143a908331b29f97ba73f4f211