### PR TITLE
Improve tokenization performance

### DIFF
--- a/src/lexer/IdentifierReader.js
+++ b/src/lexer/IdentifierReader.js
@@ -1,12 +1,24 @@
 // §4.1 IdentifierReader
 
+function isIdentifierStart(ch) {
+  return (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '_'
+  );
+}
+
+function isIdentifierPart(ch) {
+  return isIdentifierStart(ch) || (ch >= '0' && ch <= '9');
+}
+
 export function IdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
-  if (ch === null || !/[A-Za-z_]/.test(ch)) return null;
+  if (ch === null || !isIdentifierStart(ch)) return null;
 
   let value = '';
-  while (ch !== null && /[A-Za-z0-9_]/.test(ch)) {
+  while (ch !== null && isIdentifierPart(ch)) {
     value += ch;
     stream.advance();
     ch = stream.current();

--- a/src/lexer/NumberReader.js
+++ b/src/lexer/NumberReader.js
@@ -1,12 +1,16 @@
 // §4.2 NumberReader
+function isDigit(ch) {
+  return ch !== null && ch >= '0' && ch <= '9';
+}
+
 export function NumberReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
-  if (!/\d/.test(ch)) return null;
+  if (!isDigit(ch)) return null;
 
   let value = '';
   // integer part
-  while (ch !== null && /\d/.test(ch)) {
+  while (ch !== null && isDigit(ch)) {
     value += ch;
     stream.advance();
     ch = stream.current();
@@ -16,7 +20,7 @@ export function NumberReader(stream, factory) {
     value += '.';
     stream.advance();
     ch = stream.current();
-    while (ch !== null && /\d/.test(ch)) {
+    while (ch !== null && isDigit(ch)) {
       value += ch;
       stream.advance();
       ch = stream.current();

--- a/src/lexer/OperatorReader.js
+++ b/src/lexer/OperatorReader.js
@@ -7,10 +7,9 @@ const ops = JavaScriptGrammar.operators
 
 export function OperatorReader(stream, factory) {
   const startPos = stream.getPosition();
-  const rest = stream.input.slice(stream.index);
   for (const op of ops) {
-    if (rest.startsWith(op)) {
-      // consume
+    if (stream.input.startsWith(op, stream.index)) {
+      // consume without creating intermediate substrings
       for (let i = 0; i < op.length; i++) stream.advance();
       const endPos = stream.getPosition();
       return factory('OPERATOR', op, startPos, endPos);

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -16,9 +16,10 @@ export function RegexOrDivideReader(stream, factory) {
   // Look backwards for the last non-whitespace character to guess context
   let i = startPos.index - 1;
   let prev = null;
+  const WS = new Set([' ', '\n', '\t', '\r', '\v', '\f']);
   while (i >= 0) {
     const ch = stream.input[i];
-    if (/\s/.test(ch)) { i--; continue; }
+    if (WS.has(ch)) { i--; continue; }
     prev = ch;
     break;
   }
@@ -68,8 +69,11 @@ export function RegexOrDivideReader(stream, factory) {
 
   // Collect flags
   let flags = '';
-  while (!stream.eof() && /[a-z]/i.test(stream.current())) {
-    flags += stream.current();
+  while (!stream.eof()) {
+    const ch = stream.current();
+    const code = ch.charCodeAt(0);
+    if (!((code >= 65 && code <= 90) || (code >= 97 && code <= 122))) break;
+    flags += ch;
     stream.advance();
   }
 

--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -3,8 +3,10 @@
  * Consumes consecutive whitespace characters.
  * Does not emit a token; callers may attach trivia if needed.
  */
+const WHITESPACE = new Set([' ', '\n', '\t', '\r', '\v', '\f']);
+
 export function WhitespaceReader(stream) {
-  while (!stream.eof() && /\s/.test(stream.current())) {
+  while (!stream.eof() && WHITESPACE.has(stream.current())) {
     stream.advance();
   }
   // No token is returned for whitespace.


### PR DESCRIPTION
## Summary
- speed up OperatorReader by avoiding substring allocations
- replace regex checks with char comparisons in number and identifier readers
- optimize whitespace and flag handling

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node tests/benchmarks/lexer.bench.js`

------
https://chatgpt.com/codex/tasks/task_e_6851fdecd07483319ab7f02b57492583