### PR TITLE
Add IncrementalLexer for editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ Measure lexing throughput on the sample files in `tests/fixtures`:
 node tests/benchmarks/lexer.bench.js
 ```
 
+## Integration Hooks
+
+For editor integrations or other tooling that requires incremental lexing,
+use the `IncrementalLexer` exported from `index.js`. Tokens will be emitted
+as new source text is fed into the lexer, enabling real-time syntax
+highlighting or analysis.
+
+```javascript
+import { IncrementalLexer } from 'experimental-js-lexer';
+
+const collected = [];
+const lexer = new IncrementalLexer({ onToken: t => collected.push(t.type) });
+
+lexer.feed('let x');
+lexer.feed(' = 1;');
+
+console.log(collected);
+// ['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION']
+```
+
 ## Auto-Merge Workflow
 
 Pull requests labeled `reader` are automatically merged once all CI checks

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { CharStream } from "./src/lexer/CharStream.js";
 import { LexerEngine } from "./src/lexer/LexerEngine.js";
+import { IncrementalLexer } from "./src/integration/IncrementalLexer.js";
 import { fileURLToPath } from "url";
 
 /**
@@ -22,6 +23,8 @@ export function tokenize(code, { verbose = false } = {}) {
   }
   return tokens;
 }
+
+export { IncrementalLexer };
 
 // Only run CLI when invoked directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/integration/IncrementalLexer.js
+++ b/src/integration/IncrementalLexer.js
@@ -1,0 +1,34 @@
+import { CharStream } from '../lexer/CharStream.js';
+import { LexerEngine } from '../lexer/LexerEngine.js';
+
+/**
+ * IncrementalLexer allows feeding code chunks and emits tokens as they are produced.
+ */
+export class IncrementalLexer {
+  constructor({ onToken } = {}) {
+    this.onToken = onToken || (() => {});
+    this.tokens = [];
+    this.stream = new CharStream('');
+    this.engine = new LexerEngine(this.stream);
+  }
+
+  /**
+   * Feed additional source text to the lexer.
+   * @param {string} chunk
+   */
+  feed(chunk) {
+    this.stream.input += chunk;
+    let token;
+    while ((token = this.engine.nextToken()) !== null) {
+      this.tokens.push(token);
+      this.onToken(token);
+    }
+  }
+
+  /**
+   * Return all tokens produced so far.
+   */
+  getTokens() {
+    return this.tokens.slice();
+  }
+}

--- a/tests/incremental.test.js
+++ b/tests/incremental.test.js
@@ -1,0 +1,35 @@
+import { IncrementalLexer } from '../src/integration/IncrementalLexer.js';
+
+test('incremental lexer emits tokens as chunks are fed', () => {
+  const types = [];
+  const lexer = new IncrementalLexer({ onToken: t => types.push(t.type) });
+  lexer.feed('let x');
+  lexer.feed(' = 1;');
+  expect(types).toEqual([
+    'KEYWORD',
+    'IDENTIFIER',
+    'OPERATOR',
+    'NUMBER',
+    'PUNCTUATION'
+  ]);
+});
+
+test('getTokens returns accumulated tokens', () => {
+  const lexer = new IncrementalLexer();
+  lexer.feed('let a');
+  lexer.feed(' = 2;');
+  const types = lexer.getTokens().map(t => t.type);
+  expect(types).toEqual([
+    'KEYWORD',
+    'IDENTIFIER',
+    'OPERATOR',
+    'NUMBER',
+    'PUNCTUATION'
+  ]);
+});
+
+test('feeding whitespace only produces no tokens', () => {
+  const lexer = new IncrementalLexer();
+  lexer.feed('   ');
+  expect(lexer.getTokens()).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- export `IncrementalLexer` for feeding chunks of code
- document integration hooks in README
- test incremental lexing behaviour

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6851fe33e9248331b26d003476e185be