### PR TITLE
Improve lexer error reporting

### DIFF
--- a/src/lexer/LexerError.js
+++ b/src/lexer/LexerError.js
@@ -1,10 +1,27 @@
 export class LexerError extends Error {
-  constructor(type, message, start, end) {
+  constructor(type, message, start, end, input = null) {
     super(message);
     this.name = 'LexerError';
     this.type = type;
     this.start = start;
     this.end = end;
+    this.input = input;
+  }
+
+  get location() {
+    return `line ${this.start.line}, column ${this.start.column}`;
+  }
+
+  get context() {
+    if (!this.input) return '';
+    const line = this.input.split(/\r?\n/)[this.start.line - 1] || '';
+    const caret = ' '.repeat(this.start.column) + '^';
+    return `${line}\n${caret}`;
+  }
+
+  toString() {
+    const ctx = this.context ? `\n${this.context}` : '';
+    return `LexerError[${this.type}] ${this.message} at ${this.location}${ctx}`;
   }
 
   toJSON() {

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -60,7 +60,8 @@ export function RegexOrDivideReader(stream, factory) {
       'UnterminatedRegex',
       'Unterminated regular expression literal',
       startPos,
-      stream.getPosition()
+      stream.getPosition(),
+      stream.input
     );
   }
 

--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -26,7 +26,8 @@ export function TemplateStringReader(stream, factory) {
           'BadEscape',
           'Bad escape sequence in template literal',
           escStart,
-          stream.getPosition()
+          stream.getPosition(),
+          stream.input
         );
       }
       value += stream.current();
@@ -80,6 +81,7 @@ export function TemplateStringReader(stream, factory) {
     'UnterminatedTemplate',
     'Unterminated template literal',
     startPos,
-    stream.getPosition()
+    stream.getPosition(),
+    stream.input
   );
 }

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -34,4 +34,5 @@ test("RegexOrDivideReader returns LexerError on unterminated regex", () => {
   const result = RegexOrDivideReader(stream, (t, v, s, e) => new Token(t, v, s, e));
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe("UnterminatedRegex");
+  expect(result.toString()).toContain("line 1, column 0");
 });

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -34,6 +34,7 @@ test("TemplateStringReader returns LexerError on unterminated template", () => {
   );
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('UnterminatedTemplate');
+  expect(result.toString()).toContain('line 1, column 0');
 });
 
 test("TemplateStringReader returns LexerError on bad escape", () => {
@@ -44,6 +45,7 @@ test("TemplateStringReader returns LexerError on bad escape", () => {
   );
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('BadEscape');
+  expect(result.toString()).toContain('line 1, column 5');
 });
 
 test("TemplateStringReader handles escapes and nested braces", () => {


### PR DESCRIPTION
## Summary
- enhance `LexerError` with context and location helpers
- include source input when constructing errors
- verify location info in error unit tests

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6851fe4a9b64833196a15d5b23f7c655