### PR TITLE
Add streaming token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ console.log(collected);
 // ['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION']
 ```
 
+For editors that prefer a standard Node stream interface, use the
+`createTokenStream` helper:
+
+```javascript
+import { createTokenStream } from 'experimental-js-lexer';
+
+const stream = createTokenStream('let x = 1;');
+stream.on('data', tok => {
+  console.log(tok.type);
+});
+```
+
+See `docs/VS_CODE_EXAMPLE.md` for a more complete VS Code integration example.
+
 ## Auto-Merge Workflow
 
 Pull requests labeled `reader` are automatically merged once all CI checks

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -80,3 +80,17 @@ import { tokenize } from "./index.js";
 const tokens = tokenize("const a = /re/g;");
 ```
 `tokens` is an array of `Token` objects. Setting `{ verbose: true }` logs tokens as they are produced. Custom readers may be added by pushing to `LexerEngine.modes.default` before tokenization.
+
+### Streaming Tokens for Syntax Highlighting
+
+The `createTokenStream` helper in `src/integration` returns a Node.js `Readable`
+that emits each token object. This is useful for editor integrations that rely
+on streaming lexers.
+
+```javascript
+import { createTokenStream } from '../index.js';
+const stream = createTokenStream('let x = 1;');
+stream.on('data', token => {
+  console.log(token.type);
+});
+```

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -14,8 +14,8 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Expand grammar and tests to validate new tokens.
 
 ## 17. Syntax Highlighting Integration
-- [ ] Expose a stable API that streams tokens for editor consumption.
-- [ ] Provide a reference integration example for a popular editor.
+- [x] Expose a stable API that streams tokens for editor consumption.
+- [x] Provide a reference integration example for a popular editor.
 
 ## 19. TypeScript Support
 - [ ] Migrate source files to TypeScript or generate `.d.ts` declarations.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -47,7 +47,7 @@
 - [x] Expand `docs/LEXER_SPEC.md` with more edge-case examples and add clear usage snippets and 'getting started' examples.
 
 ### 17. Syntax Highlighting Integration
-- [ ] Build a syntax-highlighting integration hook so editors can consume tokens directly.
+- [x] Build a syntax-highlighting integration hook so editors can consume tokens directly.
 
 ### 18. Error Reporting Improvements
 - [x] Enhance `LexerError` to include source context (line, column, snippet) and meaningful messages.

--- a/docs/VS_CODE_EXAMPLE.md
+++ b/docs/VS_CODE_EXAMPLE.md
@@ -1,0 +1,21 @@
+# VS Code Integration Example
+
+This snippet demonstrates how to consume the lexer output using the
+`createTokenStream` helper. Tokens are streamed in real time and can be
+forwarded to the VS Code semantic highlighting API.
+
+```javascript
+import { createTokenStream } from 'experimental-js-lexer';
+
+export function provideDocumentSemanticTokens(text) {
+  return new Promise((resolve) => {
+    const tokens = [];
+    const stream = createTokenStream(text);
+    stream.on('data', token => {
+      // map token.type to VS Code Semantic Token legends
+      tokens.push(token);
+    });
+    stream.on('end', () => resolve(tokens));
+  });
+}
+```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import { CharStream } from "./src/lexer/CharStream.js";
 import { LexerEngine } from "./src/lexer/LexerEngine.js";
 import { IncrementalLexer } from "./src/integration/IncrementalLexer.js";
+import { createTokenStream } from "./src/integration/TokenStream.js";
 import { fileURLToPath } from "url";
 
 /**
@@ -24,7 +25,7 @@ export function tokenize(code, { verbose = false } = {}) {
   return tokens;
 }
 
-export { IncrementalLexer };
+export { IncrementalLexer, createTokenStream };
 
 // Only run CLI when invoked directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/integration/TokenStream.js
+++ b/src/integration/TokenStream.js
@@ -1,0 +1,24 @@
+import { Readable } from 'stream';
+import { CharStream } from '../lexer/CharStream.js';
+import { LexerEngine } from '../lexer/LexerEngine.js';
+
+/**
+ * Create a Readable stream that emits tokens for syntax highlighting.
+ * @param {string} code Source code to tokenize
+ * @returns {Readable}
+ */
+export function createTokenStream(code) {
+  const stream = new CharStream(code);
+  const engine = new LexerEngine(stream);
+  return new Readable({
+    objectMode: true,
+    read() {
+      const tok = engine.nextToken();
+      if (tok) {
+        this.push(tok);
+      } else {
+        this.push(null);
+      }
+    }
+  });
+}

--- a/tests/tokenStream.test.js
+++ b/tests/tokenStream.test.js
@@ -1,0 +1,17 @@
+import { createTokenStream } from '../src/integration/TokenStream.js';
+
+test('token stream emits tokens sequentially', done => {
+  const stream = createTokenStream('let x = 1;');
+  const types = [];
+  stream.on('data', t => types.push(t.type));
+  stream.on('end', () => {
+    expect(types).toEqual([
+      'KEYWORD',
+      'IDENTIFIER',
+      'OPERATOR',
+      'NUMBER',
+      'PUNCTUATION'
+    ]);
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
- expose `createTokenStream` for syntax highlighting integrations
- document token stream usage and VS Code example
- add tests for new token stream
- update task checklist

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685218ec5b78833188b9958a72019570