### PR TITLE
test: expand fuzz coverage for readers

### DIFF
--- a/src/lexer/BinaryReader.js
+++ b/src/lexer/BinaryReader.js
@@ -1,0 +1,23 @@
+export function BinaryReader(stream, factory) {
+  // simple placeholder that matches 0b or 0B prefix followed by binary digits
+  const startPos = stream.getPosition();
+  if (stream.current() !== '0') return null;
+  const prefix = stream.peek();
+  if (prefix !== 'b' && prefix !== 'B') return null;
+
+  let idx = stream.index + 2;
+  const ch = stream.input[idx];
+  if (ch !== '0' && ch !== '1') return null;
+
+  let value = '0' + prefix;
+  stream.advance();
+  stream.advance();
+
+  while (stream.current() === '0' || stream.current() === '1') {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -1,0 +1,43 @@
+export function ExponentReader(stream, factory) {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+  if (ch === null || ch < '0' || ch > '9') return null;
+
+  let value = '';
+  while (ch !== null && ch >= '0' && ch <= '9') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  if (ch !== 'e' && ch !== 'E') {
+    // rewind
+    stream.index = startPos.index;
+    return null;
+  }
+
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+
+  if (ch === '+' || ch === '-') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  if (ch === null || ch < '0' || ch > '9') {
+    // invalid exponent
+    stream.index = startPos.index;
+    return null;
+  }
+
+  while (ch !== null && ch >= '0' && ch <= '9') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -1,0 +1,33 @@
+export function NumericSeparatorReader(stream, factory) {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+  if (ch === null || ch < '0' || ch > '9') return null;
+
+  let value = '';
+  let lastUnderscore = false;
+  while (ch !== null) {
+    if (ch === '_') {
+      if (lastUnderscore) {
+        stream.index = startPos.index;
+        return null;
+      }
+      lastUnderscore = true;
+      value += ch;
+    } else if (ch >= '0' && ch <= '9') {
+      lastUnderscore = false;
+      value += ch;
+    } else {
+      break;
+    }
+    stream.advance();
+    ch = stream.current();
+  }
+
+  if (value.includes('_')) {
+    const endPos = stream.getPosition();
+    return factory('NUMBER', value, startPos, endPos);
+  }
+
+  stream.index = startPos.index;
+  return null;
+}

--- a/src/lexer/OctalReader.js
+++ b/src/lexer/OctalReader.js
@@ -1,0 +1,22 @@
+export function OctalReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '0') return null;
+  const prefix = stream.peek();
+  if (prefix !== 'o' && prefix !== 'O') return null;
+
+  let idx = stream.index + 2;
+  const ch = stream.input[idx];
+  if (ch < '0' || ch > '7') return null;
+
+  let value = '0' + prefix;
+  stream.advance();
+  stream.advance();
+
+  while (stream.current() >= '0' && stream.current() <= '7') {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}

--- a/src/lexer/ShebangReader.js
+++ b/src/lexer/ShebangReader.js
@@ -1,0 +1,14 @@
+export function ShebangReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '#' || stream.peek() !== '!') return null;
+
+  let value = '';
+  while (!stream.eof() && stream.current() !== '\n') {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('COMMENT', value, startPos, endPos);
+}

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,0 +1,14 @@
+export function UnicodeIdentifierReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const ch = stream.current();
+  if (ch === null || ch.charCodeAt(0) < 128) return null;
+
+  let value = '';
+  while (stream.current() !== null && stream.current().charCodeAt(0) >= 128) {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('IDENTIFIER', value, startPos, endPos);
+}

--- a/tests/fuzz.test.js
+++ b/tests/fuzz.test.js
@@ -12,6 +12,12 @@ import { PunctuationReader } from "../src/lexer/PunctuationReader.js";
 import { RegexOrDivideReader } from "../src/lexer/RegexOrDivideReader.js";
 import { TemplateStringReader } from "../src/lexer/TemplateStringReader.js";
 import { WhitespaceReader } from "../src/lexer/WhitespaceReader.js";
+import { BinaryReader } from "../src/lexer/BinaryReader.js";
+import { OctalReader } from "../src/lexer/OctalReader.js";
+import { ExponentReader } from "../src/lexer/ExponentReader.js";
+import { NumericSeparatorReader } from "../src/lexer/NumericSeparatorReader.js";
+import { UnicodeIdentifierReader } from "../src/lexer/UnicodeIdentifierReader.js";
+import { ShebangReader } from "../src/lexer/ShebangReader.js";
 
 function randomAsciiString(maxLen = 20) {
   const len = Math.floor(Math.random() * (maxLen + 1));
@@ -24,7 +30,7 @@ function randomAsciiString(maxLen = 20) {
 }
 
 // generate a pool of random inputs once so each test uses the same set
-const FUZZ_INPUTS = Array.from({ length: 20 }, () => randomAsciiString());
+const FUZZ_INPUTS = Array.from({ length: 50 }, () => randomAsciiString());
 const READERS = [
   ["IdentifierReader", IdentifierReader],
   ["NumberReader", NumberReader],
@@ -33,6 +39,12 @@ const READERS = [
   ["RegexOrDivideReader", RegexOrDivideReader],
   ["TemplateStringReader", TemplateStringReader],
   ["WhitespaceReader", WhitespaceReader],
+  ["BinaryReader", BinaryReader],
+  ["OctalReader", OctalReader],
+  ["ExponentReader", ExponentReader],
+  ["NumericSeparatorReader", NumericSeparatorReader],
+  ["UnicodeIdentifierReader", UnicodeIdentifierReader],
+  ["ShebangReader", ShebangReader],
 ];
 
 READERS.forEach(([name, reader]) => {


### PR DESCRIPTION
## Summary
- fuzz new numeric and misc readers with random inputs
- bump fuzz sample count to 50
- add placeholder implementations for upcoming readers so tests run

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685235020ad883319474e9e1f1d97f5c