### PR TITLE
Implement OctalReader tests and engine integration

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -65,6 +65,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
+- `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
-- [ ] Implement OctalReader (0o… literals)
+- [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
 - [ ] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -1,5 +1,6 @@
 import { IdentifierReader } from './IdentifierReader.js';
 import { HexReader } from './HexReader.js';
+import { OctalReader } from './OctalReader.js';
 import { BigIntReader } from './BigIntReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
@@ -39,6 +40,7 @@ export class LexerEngine {
         WhitespaceReader,
         IdentifierReader,
         HexReader,
+        OctalReader,
         BigIntReader,
         NumberReader,
         StringReader,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -57,3 +57,15 @@ test("integration: hex literals", () => {
   ]);
   expect(toks[3].value).toBe("0x1A");
 });
+
+test("integration: octal literals", () => {
+  const toks = tokenize("let n = 0o755;");
+  expect(toks.map(t => t.type)).toEqual([
+    "KEYWORD",
+    "IDENTIFIER",
+    "OPERATOR",
+    "NUMBER",
+    "PUNCTUATION"
+  ]);
+  expect(toks[3].value).toBe("0o755");
+});

--- a/tests/readers/OctalReader.test.js
+++ b/tests/readers/OctalReader.test.js
@@ -1,0 +1,35 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { OctalReader } from "../../src/lexer/OctalReader.js";
+
+ test("OctalReader reads lowercase prefix", () => {
+   const stream = new CharStream("0o755");
+   const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+   expect(tok.type).toBe("NUMBER");
+   expect(tok.value).toBe("0o755");
+   expect(stream.getPosition().index).toBe(5);
+ });
+
+ test("OctalReader reads uppercase prefix", () => {
+   const stream = new CharStream("0O644");
+   const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+   expect(tok.type).toBe("NUMBER");
+   expect(tok.value).toBe("0O644");
+   expect(stream.getPosition().index).toBe(5);
+ });
+
+ test("OctalReader returns null when not octal", () => {
+   const stream = new CharStream("123");
+   const pos = stream.getPosition();
+   const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+   expect(tok).toBeNull();
+   expect(stream.getPosition()).toEqual(pos);
+ });
+
+ test("OctalReader returns null without digits", () => {
+   const stream = new CharStream("0o");
+   const pos = stream.getPosition();
+   const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+   expect(tok).toBeNull();
+   expect(stream.getPosition()).toEqual(pos);
+ });


### PR DESCRIPTION
## Summary
- mark OctalReader as complete in TODO list
- document OctalReader in lexer spec
- wire OctalReader into LexerEngine
- test Octal literals in integration tests
- add unit tests for OctalReader

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- --coverage --runInBand` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6852387cb4b483319137f20bb0390ccd