### PR TITLE
Implement OctalReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -65,6 +65,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
+- `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
-- [ ] Implement OctalReader (0o… literals)
+- [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
 - [ ] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -1,5 +1,6 @@
 import { IdentifierReader } from './IdentifierReader.js';
 import { HexReader } from './HexReader.js';
+import { OctalReader } from './OctalReader.js';
 import { BigIntReader } from './BigIntReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
@@ -39,6 +40,7 @@ export class LexerEngine {
         WhitespaceReader,
         IdentifierReader,
         HexReader,
+        OctalReader,
         BigIntReader,
         NumberReader,
         StringReader,

--- a/src/lexer/OctalReader.js
+++ b/src/lexer/OctalReader.js
@@ -4,15 +4,19 @@ export function OctalReader(stream, factory) {
   const prefix = stream.peek();
   if (prefix !== 'o' && prefix !== 'O') return null;
 
-  let idx = stream.index + 2;
+  const idx = stream.index + 2;
   const ch = stream.input[idx];
-  if (ch < '0' || ch > '7') return null;
+  if (!ch || ch < '0' || ch > '7') return null;
 
   let value = '0' + prefix;
   stream.advance();
   stream.advance();
 
-  while (stream.current() >= '0' && stream.current() <= '7') {
+  while (
+    stream.current() !== null &&
+    stream.current() >= '0' &&
+    stream.current() <= '7'
+  ) {
     value += stream.current();
     stream.advance();
   }

--- a/tests/readers/OctalReader.test.js
+++ b/tests/readers/OctalReader.test.js
@@ -1,0 +1,35 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { OctalReader } from "../../src/lexer/OctalReader.js";
+
+test("OctalReader reads lowercase prefix", () => {
+  const stream = new CharStream("0o17");
+  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("0o17");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("OctalReader reads uppercase prefix", () => {
+  const stream = new CharStream("0O755");
+  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("0O755");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("OctalReader returns null when not octal", () => {
+  const stream = new CharStream("123");
+  const pos = stream.getPosition();
+  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("OctalReader returns null without digits", () => {
+  const stream = new CharStream("0o");
+  const pos = stream.getPosition();
+  const tok = OctalReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- add OctalReader tests and integrate reader
- update LexerEngine to use OctalReader
- document OctalReader in lexer spec
- check off OctalReader in TODO list

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- --coverage --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68523890efd88331afc2214cc3055844