### PR TITLE
Add OctalReader integration

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -18,7 +18,8 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `IdentifierReader` (§4.1)
 - `NumberReader` (§4.2)
 - `HexReader` (§4.3)
-- `BigIntReader` (§4.4)
+- `OctalReader` (§4.4)
+- `BigIntReader` (§4.5)
 - `OperatorReader` (§4.5)
 - `PunctuationReader` (§4.6)
 - `RegexOrDivideReader` (§4.7)
@@ -65,6 +66,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
+- `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
-- [ ] Implement OctalReader (0o… literals)
+- [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
 - [ ] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -1,6 +1,7 @@
 import { IdentifierReader } from './IdentifierReader.js';
 import { HexReader } from './HexReader.js';
 import { BigIntReader } from './BigIntReader.js';
+import { OctalReader } from './OctalReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
@@ -40,6 +41,7 @@ export class LexerEngine {
         IdentifierReader,
         HexReader,
         BigIntReader,
+        OctalReader,
         NumberReader,
         StringReader,
         RegexOrDivideReader,


### PR DESCRIPTION
## Summary
- integrate `OctalReader` into `LexerEngine`
- update lexer spec and TODO checklist

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6852387cb4b483319137f20bb0390ccd