### PR TITLE
Add numeric and Unicode reader implementations

### DIFF
--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -2,11 +2,11 @@
 
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
-- [ ] Implement OctalReader (0o… literals)
-- [ ] Implement ExponentReader (1e… literals)
-- [ ] Implement NumericSeparatorReader (1_000 separators)
-- [ ] Implement UnicodeIdentifierReader (full Unicode support)
-- [ ] Implement ShebangReader (#!… file headers)
-- [ ] Buffer tokens in BufferedIncrementalLexer
+- [x] Implement OctalReader (0o… literals)
+- [x] Implement ExponentReader (1e… literals)
+- [x] Implement NumericSeparatorReader (1_000 separators)
+- [x] Implement UnicodeIdentifierReader (full Unicode support)
+- [x] Implement ShebangReader (#!… file headers)
+- [x] Buffer tokens in BufferedIncrementalLexer
 - [x] Scaffold VS Code Extension under `extension/`
 - [ ] Enhance RegexOrDivideReader to handle character classes

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -1,0 +1,35 @@
+import { CharStream } from '../lexer/CharStream.js';
+import { LexerEngine } from '../lexer/LexerEngine.js';
+
+/**
+ * BufferedIncrementalLexer buffers incomplete input across feeds
+ * so tokens spanning chunks are produced correctly.
+ */
+export class BufferedIncrementalLexer {
+  constructor({ onToken } = {}) {
+    this.onToken = onToken || (() => {});
+    this.buffer = '';
+    this.tokens = [];
+    this.stream = new CharStream('');
+    this.engine = new LexerEngine(this.stream);
+  }
+
+  feed(chunk) {
+    this.buffer += chunk;
+    this.stream.input = this.buffer;
+    let token;
+    let lastIndex = 0;
+    while ((token = this.engine.nextToken()) !== null) {
+      lastIndex = this.stream.getPosition().index;
+      this.tokens.push(token);
+      this.onToken(token);
+    }
+    this.buffer = this.buffer.slice(lastIndex);
+    this.stream = new CharStream(this.buffer);
+    this.engine = new LexerEngine(this.stream);
+  }
+
+  getTokens() {
+    return this.tokens.slice();
+  }
+}

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -12,7 +12,7 @@ export function ExponentReader(stream, factory) {
 
   if (ch !== 'e' && ch !== 'E') {
     // rewind
-    stream.index = startPos.index;
+    stream.setPosition(startPos);
     return null;
   }
 
@@ -28,7 +28,7 @@ export function ExponentReader(stream, factory) {
 
   if (ch === null || ch < '0' || ch > '9') {
     // invalid exponent
-    stream.index = startPos.index;
+    stream.setPosition(startPos);
     return null;
   }
 

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -10,6 +10,12 @@ import { TemplateStringReader } from './TemplateStringReader.js';
 import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
+import { ShebangReader } from './ShebangReader.js';
+import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
+import { BinaryReader } from './BinaryReader.js';
+import { OctalReader } from './OctalReader.js';
+import { ExponentReader } from './ExponentReader.js';
+import { NumericSeparatorReader } from './NumericSeparatorReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -37,8 +43,14 @@ export class LexerEngine {
       default: [
         CommentReader,
         WhitespaceReader,
+        ShebangReader,
+        UnicodeIdentifierReader,
         IdentifierReader,
         HexReader,
+        BinaryReader,
+        OctalReader,
+        ExponentReader,
+        NumericSeparatorReader,
         BigIntReader,
         NumberReader,
         StringReader,

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -8,7 +8,7 @@ export function NumericSeparatorReader(stream, factory) {
   while (ch !== null) {
     if (ch === '_') {
       if (lastUnderscore) {
-        stream.index = startPos.index;
+        stream.setPosition(startPos);
         return null;
       }
       lastUnderscore = true;
@@ -28,6 +28,6 @@ export function NumericSeparatorReader(stream, factory) {
     return factory('NUMBER', value, startPos, endPos);
   }
 
-  stream.index = startPos.index;
+  stream.setPosition(startPos);
   return null;
 }

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,12 +1,29 @@
+function isAsciiIdentifierPart(ch) {
+  return (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    (ch >= '0' && ch <= '9') ||
+    ch === '_'
+  );
+}
+
 export function UnicodeIdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
-  const ch = stream.current();
+  let ch = stream.current();
   if (ch === null || ch.charCodeAt(0) < 128) return null;
 
   let value = '';
-  while (stream.current() !== null && stream.current().charCodeAt(0) >= 128) {
-    value += stream.current();
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+
+  while (
+    ch !== null &&
+    (ch.charCodeAt(0) >= 128 || isAsciiIdentifierPart(ch))
+  ) {
+    value += ch;
     stream.advance();
+    ch = stream.current();
   }
 
   const endPos = stream.getPosition();

--- a/tests/bufferedIncremental.test.js
+++ b/tests/bufferedIncremental.test.js
@@ -1,0 +1,11 @@
+import { BufferedIncrementalLexer } from "../src/integration/BufferedIncrementalLexer.js";
+
+test("BufferedIncrementalLexer buffers across chunks", () => {
+  const lexer = new BufferedIncrementalLexer();
+  lexer.feed("let a = 1");
+  let types = lexer.getTokens().map(t => t.type);
+  expect(types).toEqual(["KEYWORD", "IDENTIFIER", "OPERATOR", "NUMBER"]);
+  lexer.feed(";");
+  types = lexer.getTokens().map(t => t.type);
+  expect(types).toEqual(["KEYWORD", "IDENTIFIER", "OPERATOR", "NUMBER", "PUNCTUATION"]);
+});

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -1,0 +1,35 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ExponentReader } from "../../src/lexer/ExponentReader.js";
+
+test("ExponentReader reads simple exponent", () => {
+  const stream = new CharStream("1e10");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1e10");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader handles sign", () => {
+  const stream = new CharStream("2E-3");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("2E-3");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader returns null when not exponent", () => {
+  const stream = new CharStream("123");
+  const pos = stream.getPosition();
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("ExponentReader returns null on invalid exponent", () => {
+  const stream = new CharStream("1e");
+  const pos = stream.getPosition();
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/NumericSeparatorReader.test.js
+++ b/tests/readers/NumericSeparatorReader.test.js
@@ -1,0 +1,27 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { NumericSeparatorReader } from "../../src/lexer/NumericSeparatorReader.js";
+
+test("NumericSeparatorReader reads separated number", () => {
+  const stream = new CharStream("1_000");
+  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1_000");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("NumericSeparatorReader rejects double underscore", () => {
+  const stream = new CharStream("1__0");
+  const pos = stream.getPosition();
+  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("NumericSeparatorReader returns null when no underscore", () => {
+  const stream = new CharStream("123");
+  const pos = stream.getPosition();
+  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/OctalReader.test.js
+++ b/tests/readers/OctalReader.test.js
@@ -1,0 +1,35 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { OctalReader } from "../../src/lexer/OctalReader.js";
+
+test("OctalReader reads lowercase prefix", () => {
+  const stream = new CharStream("0o77");
+  const tok = OctalReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("0o77");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("OctalReader reads uppercase prefix", () => {
+  const stream = new CharStream("0O10");
+  const tok = OctalReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("0O10");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("OctalReader returns null when not octal", () => {
+  const stream = new CharStream("123");
+  const pos = stream.getPosition();
+  const tok = OctalReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("OctalReader returns null without digits", () => {
+  const stream = new CharStream("0o");
+  const pos = stream.getPosition();
+  const tok = OctalReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/ShebangReader.test.js
+++ b/tests/readers/ShebangReader.test.js
@@ -1,0 +1,20 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ShebangReader } from "../../src/lexer/ShebangReader.js";
+
+test("ShebangReader reads shebang at start", () => {
+  const stream = new CharStream("#!/usr/bin/env node\nconst a = 1;");
+  const tok = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("COMMENT");
+  expect(tok.value).toBe("#!/usr/bin/env node");
+  expect(stream.getPosition().line).toBe(1);
+  expect(stream.getPosition().column).toBe(19);
+});
+
+test("ShebangReader returns null when not at start", () => {
+  const stream = new CharStream(" const x = 1;");
+  const pos = stream.getPosition();
+  const tok = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/UnicodeIdentifierReader.test.js
+++ b/tests/readers/UnicodeIdentifierReader.test.js
@@ -1,0 +1,19 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { UnicodeIdentifierReader } from "../../src/lexer/UnicodeIdentifierReader.js";
+
+test("UnicodeIdentifierReader reads unicode identifier", () => {
+  const stream = new CharStream("Ωmega");
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("IDENTIFIER");
+  expect(tok.value).toBe("Ωmega");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("UnicodeIdentifierReader returns null for ascii", () => {
+  const stream = new CharStream("abc");
+  const pos = stream.getPosition();
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement additional numeric readers and Unicode identifier reader
- expose new readers in `LexerEngine`
- introduce `BufferedIncrementalLexer`
- add extensive unit tests
- update TODO checklist

## Testing
- `npm run lint`
- `npm test -- --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6852387cb4b483319137f20bb0390ccd