### PR TITLE
feat: support regex char classes

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -61,6 +61,8 @@ Each is a pure function `(stream, factory) => Token|null`:
 - Multi-line comments reaching EOF are returned as `COMMENT` tokens without error.
 - `/=` is always tokenized as the divide-assign operator before regex detection.
 - Regex or divide context is inferred from the last non-whitespace character.
+- Character classes inside regex literals are parsed, ignoring `/` characters
+  until the closing `]`.
 - Template strings track nested `${ ... }` braces and handle escapes.
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -9,4 +9,4 @@
 - [ ] Implement ShebangReader (#!… file headers)
 - [ ] Buffer tokens in BufferedIncrementalLexer
 - [x] Scaffold VS Code Extension under `extension/`
-- [ ] Enhance RegexOrDivideReader to handle character classes
+- [x] Enhance RegexOrDivideReader to handle character classes

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -41,16 +41,30 @@ export function RegexOrDivideReader(stream, factory) {
 
   let body = '';
   let escaped = false;
+  let inCharClass = false;
   while (!stream.eof()) {
     const ch = stream.current();
-    if (!escaped && ch === '/') break;
-    if (!escaped && ch === '\\') {
-      escaped = true;
-      body += ch;
-      stream.advance();
-      continue;
+    if (!escaped) {
+      if (ch === '\\') {
+        escaped = true;
+        body += ch;
+        stream.advance();
+        continue;
+      }
+
+      if (inCharClass) {
+        if (ch === ']') inCharClass = false;
+      } else {
+        if (ch === '[') {
+          inCharClass = true;
+        } else if (ch === '/') {
+          break;
+        }
+      }
+    } else {
+      escaped = false;
     }
-    escaped = false;
+
     body += ch;
     stream.advance();
   }

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -44,6 +44,20 @@ test("RegexOrDivideReader handles escaped slashes", () => {
   expect(token.value).toBe("/a\\/b/i");
 });
 
+test("RegexOrDivideReader handles character classes", () => {
+  const stream = new CharStream("/[a-z]/g");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/[a-z]/g");
+});
+
+test("RegexOrDivideReader handles slashes in character classes", () => {
+  const stream = new CharStream("/[a\\/b]/");
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe("/[a\\/b]/");
+});
+
 test("RegexOrDivideReader treats context after paren as regex", () => {
   const stream = new CharStream("( /a/ )");
   stream.advance(); // (


### PR DESCRIPTION
## Summary
- support character classes in RegexOrDivideReader
- test regex char class handling
- document regex char class support
- check off TODO item

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523c6a14c083319807b48ff4135bf6