### PR TITLE
feat(reader): implement NumericSeparatorReader

### DIFF
--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -4,7 +4,7 @@
 - [x] Implement BinaryReader (0b… literals)
 - [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
-- [ ] Implement NumericSeparatorReader (1_000 separators)
+- [x] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)
 - [ ] Implement ShebangReader (#!… file headers)
 - [ ] Buffer tokens in BufferedIncrementalLexer

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -4,30 +4,31 @@ export function NumericSeparatorReader(stream, factory) {
   if (ch === null || ch < '0' || ch > '9') return null;
 
   let value = '';
+  let underscoreSeen = false;
   let lastUnderscore = false;
-  while (ch !== null) {
+
+  while (ch !== null && (ch >= '0' && ch <= '9' || ch === '_')) {
     if (ch === '_') {
       if (lastUnderscore) {
         stream.index = startPos.index;
         return null;
       }
+      underscoreSeen = true;
       lastUnderscore = true;
-      value += ch;
-    } else if (ch >= '0' && ch <= '9') {
-      lastUnderscore = false;
-      value += ch;
     } else {
-      break;
+      lastUnderscore = false;
     }
+
+    value += ch;
     stream.advance();
     ch = stream.current();
   }
 
-  if (value.includes('_')) {
-    const endPos = stream.getPosition();
-    return factory('NUMBER', value, startPos, endPos);
+  if (!underscoreSeen || lastUnderscore) {
+    stream.index = startPos.index;
+    return null;
   }
 
-  stream.index = startPos.index;
-  return null;
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
 }

--- a/tests/readers/NumericSeparatorReader.test.js
+++ b/tests/readers/NumericSeparatorReader.test.js
@@ -1,0 +1,43 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { NumericSeparatorReader } from "../../src/lexer/NumericSeparatorReader.js";
+
+test("NumericSeparatorReader reads underscores", () => {
+  const stream = new CharStream("1_000");
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1_000");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("NumericSeparatorReader returns null without underscores", () => {
+  const stream = new CharStream("1234");
+  const index = stream.getPosition().index;
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(index);
+});
+
+test("NumericSeparatorReader rejects trailing underscore", () => {
+  const stream = new CharStream("1_000_");
+  const index = stream.getPosition().index;
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(index);
+});
+
+test("NumericSeparatorReader rejects consecutive underscores", () => {
+  const stream = new CharStream("1__0");
+  const index = stream.getPosition().index;
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(index);
+});
+
+test("NumericSeparatorReader stops at non-digit", () => {
+  const stream = new CharStream("1_2a");
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1_2");
+  expect(stream.getPosition().index).toBe(3);
+});


### PR DESCRIPTION
## Summary
- implement `NumericSeparatorReader`
- add tests for underscore numeric literals
- mark task complete in TODO

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523c47a9508331a4d62ffb0f21ba37