### PR TITLE
Implement UnicodeIdentifierReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -66,6 +66,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
+- `UnicodeIdentifierReader` accepts identifier characters beyond ASCII.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -5,7 +5,7 @@
 - [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
 - [ ] Implement NumericSeparatorReader (1_000 separators)
-- [ ] Implement UnicodeIdentifierReader (full Unicode support)
+- [x] Implement UnicodeIdentifierReader (full Unicode support)
 - [ ] Implement ShebangReader (#!… file headers)
 - [ ] Buffer tokens in BufferedIncrementalLexer
 - [x] Scaffold VS Code Extension under `extension/`

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,14 +1,19 @@
+const ID_START_RE = /[\p{ID_Start}]/u;
+const ID_CONTINUE_RE = /[\p{ID_Continue}]/u;
+
 export function UnicodeIdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
-  const ch = stream.current();
-  if (ch === null || ch.charCodeAt(0) < 128) return null;
-
-  let value = '';
-  while (stream.current() !== null && stream.current().charCodeAt(0) >= 128) {
-    value += stream.current();
-    stream.advance();
+  let ch = stream.current();
+  if (ch === null || ch.charCodeAt(0) < 128 || !ID_START_RE.test(ch)) {
+    return null;
   }
 
+  let value = '';
+  while (ch !== null && ID_CONTINUE_RE.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
   const endPos = stream.getPosition();
   return factory('IDENTIFIER', value, startPos, endPos);
 }

--- a/tests/readers/UnicodeIdentifierReader.test.js
+++ b/tests/readers/UnicodeIdentifierReader.test.js
@@ -1,0 +1,27 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { UnicodeIdentifierReader } from "../../src/lexer/UnicodeIdentifierReader.js";
+
+test("UnicodeIdentifierReader reads identifier with unicode start", () => {
+  const stream = new CharStream("éfoo ");
+  const tok = UnicodeIdentifierReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("IDENTIFIER");
+  expect(tok.value).toBe("éfoo");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("UnicodeIdentifierReader returns null for ascii start", () => {
+  const stream = new CharStream("abc");
+  const pos = stream.getPosition();
+  const tok = UnicodeIdentifierReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("UnicodeIdentifierReader handles joiner characters", () => {
+  const stream = new CharStream("é\u200Dbar");
+  const tok = UnicodeIdentifierReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.value).toBe("é\u200Dbar");
+  expect(stream.getPosition().index).toBe(5);
+});
+


### PR DESCRIPTION
## Summary
- implement `UnicodeIdentifierReader` with Unicode property escapes
- document new reader in spec and mark task complete
- add tests for Unicode identifier parsing

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523c4d9e288331814fe7dbe0593caf