### PR TITLE
feat(integration): buffer incomplete tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import { CharStream } from "./src/lexer/CharStream.js";
 import { LexerEngine } from "./src/lexer/LexerEngine.js";
 import { IncrementalLexer } from "./src/integration/IncrementalLexer.js";
+import { BufferedIncrementalLexer } from "./src/integration/BufferedIncrementalLexer.js";
 import { createTokenStream } from "./src/integration/TokenStream.js";
 import { fileURLToPath } from "url";
 
@@ -27,7 +28,7 @@ export function tokenize(code, { verbose = false } = {}) {
 
 export const registerPlugin = LexerEngine.registerPlugin.bind(LexerEngine);
 export const clearPlugins = LexerEngine.clearPlugins.bind(LexerEngine);
-export { IncrementalLexer, createTokenStream };
+export { IncrementalLexer, BufferedIncrementalLexer, createTokenStream };
 
 // Only run CLI when invoked directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tests/BufferedIncrementalLexer.test.js
+++ b/tests/BufferedIncrementalLexer.test.js
@@ -1,0 +1,19 @@
+import { BufferedIncrementalLexer } from '../src/integration/BufferedIncrementalLexer.js';
+
+test('buffers incomplete string across feeds', () => {
+  const types = [];
+  const lexer = new BufferedIncrementalLexer({ onToken: t => types.push(t.type) });
+  lexer.feed('const s = "hel');
+  expect(types).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR']);
+  lexer.feed('lo";');
+  expect(types).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'STRING', 'PUNCTUATION']);
+});
+
+test('getTokens includes buffered results only when complete', () => {
+  const lexer = new BufferedIncrementalLexer();
+  lexer.feed('let a = "');
+  expect(lexer.getTokens().map(t => t.type)).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR']);
+  lexer.feed('b";');
+  expect(lexer.getTokens().map(t => t.type)).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'STRING', 'PUNCTUATION']);
+});
+


### PR DESCRIPTION
## Summary
- add `BufferedIncrementalLexer` to handle incomplete tokens across feeds
- export it from `index.js`
- test buffering behaviour

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523c5a75ac83319816af4b811546c0