### PR TITLE
Implement ExponentReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -66,6 +66,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
+- `ExponentReader` parses base-10 numbers with `e` or `E` exponents.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -67,6 +67,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `ExponentReader` parses base-10 numbers with `e` or `E` exponents.
+- `NumericSeparatorReader` parses numbers with `_` digit separators.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -4,7 +4,7 @@
 - [x] Implement BinaryReader (0b… literals)
 - [x] Implement OctalReader (0o… literals)
 - [x] Implement ExponentReader (1e… literals)
-- [ ] Implement NumericSeparatorReader (1_000 separators)
+- [x] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)
 - [ ] Implement ShebangReader (#!… file headers)
 - [ ] Buffer tokens in BufferedIncrementalLexer

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -3,7 +3,7 @@
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
 - [x] Implement OctalReader (0o… literals)
-- [ ] Implement ExponentReader (1e… literals)
+- [x] Implement ExponentReader (1e… literals)
 - [ ] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)
 - [ ] Implement ShebangReader (#!… file headers)

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -10,6 +10,17 @@ export function ExponentReader(stream, factory) {
     ch = stream.current();
   }
 
+  if (ch === '.') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+    while (ch !== null && ch >= '0' && ch <= '9') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+  }
+
   if (ch !== 'e' && ch !== 'E') {
     // rewind
     stream.index = startPos.index;

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -1,6 +1,8 @@
 import { IdentifierReader } from './IdentifierReader.js';
 import { HexReader } from './HexReader.js';
 import { BigIntReader } from './BigIntReader.js';
+import { NumericSeparatorReader } from './NumericSeparatorReader.js';
+import { ExponentReader } from './ExponentReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
@@ -40,6 +42,8 @@ export class LexerEngine {
         IdentifierReader,
         HexReader,
         BigIntReader,
+        NumericSeparatorReader,
+        ExponentReader,
         NumberReader,
         StringReader,
         RegexOrDivideReader,

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -23,7 +23,7 @@ export function NumericSeparatorReader(stream, factory) {
     ch = stream.current();
   }
 
-  if (value.includes('_')) {
+  if (value.includes('_') && !lastUnderscore) {
     const endPos = stream.getPosition();
     return factory('NUMBER', value, startPos, endPos);
   }

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -1,0 +1,36 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ExponentReader } from "../../src/lexer/ExponentReader.js";
+
+test("ExponentReader reads simple exponent", () => {
+  const stream = new CharStream("1e10");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1e10");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader reads signed exponent", () => {
+  const stream = new CharStream("2e-5");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("2e-5");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader reads decimal base", () => {
+  const stream = new CharStream("3.14e2");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("3.14e2");
+  expect(stream.getPosition().index).toBe(6);
+});
+
+test("ExponentReader returns null when format invalid", () => {
+  const stream = new CharStream("1e+");
+  const idx = stream.getPosition().index;
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(idx);
+});
+

--- a/tests/readers/NumericSeparatorReader.test.js
+++ b/tests/readers/NumericSeparatorReader.test.js
@@ -1,0 +1,34 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { NumericSeparatorReader } from "../../src/lexer/NumericSeparatorReader.js";
+
+// valid separators
+const cases = [
+  ["1_000", 5],
+  ["12_34_56", 8]
+];
+
+test.each(cases)("NumericSeparatorReader reads %s", (input, end) => {
+  const stream = new CharStream(input);
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe(input);
+  expect(stream.getPosition().index).toBe(end);
+});
+
+test("NumericSeparatorReader returns null for trailing underscore", () => {
+  const stream = new CharStream("1_");
+  const idx = stream.getPosition().index;
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(idx);
+});
+
+test("NumericSeparatorReader returns null for consecutive underscores", () => {
+  const stream = new CharStream("1__0");
+  const idx = stream.getPosition().index;
+  const tok = NumericSeparatorReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(idx);
+});
+


### PR DESCRIPTION
## Summary
- support exponent numeric literals
- document new reader and mark checklist item complete
- test ExponentReader parsing

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523c37d01483318d0fd7cde4437a45