### PR TITLE
feat(integration): buffer multiline comments

### DIFF
--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -7,6 +7,6 @@
 - [x] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)
 - [x] Implement ShebangReader (#!… file headers)
-- [ ] Buffer tokens in BufferedIncrementalLexer
+- [x] Buffer tokens in BufferedIncrementalLexer
 - [x] Scaffold VS Code Extension under `extension/`
 - [x] Enhance RegexOrDivideReader to handle character classes

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -36,6 +36,16 @@ export class BufferedIncrementalLexer {
         throw err;
       }
       if (token === null) break;
+      if (
+        token.type === 'COMMENT' &&
+        token.value.startsWith('/*') &&
+        !token.value.endsWith('*/') &&
+        this.stream.eof()
+      ) {
+        // Incomplete multi-line comment, rewind and wait for more input
+        this.stream.setPosition(pos);
+        break;
+      }
       this.tokens.push(token);
       this.onToken(token);
     }

--- a/tests/BufferedIncrementalLexer.test.js
+++ b/tests/BufferedIncrementalLexer.test.js
@@ -17,3 +17,12 @@ test('getTokens includes buffered results only when complete', () => {
   expect(lexer.getTokens().map(t => t.type)).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'STRING', 'PUNCTUATION']);
 });
 
+test('buffers incomplete multi-line comment across feeds', () => {
+  const types = [];
+  const lexer = new BufferedIncrementalLexer({ onToken: t => types.push(t.type) });
+  lexer.feed('/* hello');
+  expect(types).toEqual([]);
+  lexer.feed(' world */ let x = 1;');
+  expect(types).toEqual(['COMMENT', 'KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION']);
+});
+


### PR DESCRIPTION
## Summary
- handle unfinished block comments in BufferedIncrementalLexer
- cover multi-line comment buffering in tests
- mark checklist item completed

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68523f9e6b888331b7792121f4fad248