### PR TITLE
feat(reader): add UnicodeIdentifierReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -68,6 +68,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
+- `UnicodeIdentifierReader` reads identifiers starting with non-ASCII Unicode characters.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -5,7 +5,7 @@
 - [x] Implement OctalReader (0o… literals)
 - [ ] Implement ExponentReader (1e… literals)
 - [x] Implement NumericSeparatorReader (1_000 separators)
-- [ ] Implement UnicodeIdentifierReader (full Unicode support)
+- [x] Implement UnicodeIdentifierReader (full Unicode support)
 - [x] Implement ShebangReader (#!… file headers)
 - [ ] Buffer tokens in BufferedIncrementalLexer
 - [x] Scaffold VS Code Extension under `extension/`

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,12 +1,22 @@
+const ID_START_RE = /[\p{ID_Start}$_]/u;
+const ID_CONTINUE_RE = /[\p{ID_Continue}$_\u200C\u200D]/u;
+
 export function UnicodeIdentifierReader(stream, factory) {
   const startPos = stream.getPosition();
-  const ch = stream.current();
-  if (ch === null || ch.charCodeAt(0) < 128) return null;
+  let ch = stream.current();
 
-  let value = '';
-  while (stream.current() !== null && stream.current().charCodeAt(0) >= 128) {
-    value += stream.current();
+  if (ch === null || ch.charCodeAt(0) < 128 || !ID_START_RE.test(ch)) {
+    return null;
+  }
+
+  let value = ch;
+  stream.advance();
+  ch = stream.current();
+
+  while (ch !== null && ID_CONTINUE_RE.test(ch)) {
+    value += ch;
     stream.advance();
+    ch = stream.current();
   }
 
   const endPos = stream.getPosition();

--- a/tests/readers/UnicodeIdentifierReader.test.js
+++ b/tests/readers/UnicodeIdentifierReader.test.js
@@ -1,0 +1,34 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { UnicodeIdentifierReader } from "../../src/lexer/UnicodeIdentifierReader.js";
+
+test("UnicodeIdentifierReader reads non-ASCII identifier", () => {
+  const stream = new CharStream("πδ");
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("IDENTIFIER");
+  expect(tok.value).toBe("πδ");
+  expect(stream.getPosition().index).toBe(2);
+});
+
+test("UnicodeIdentifierReader allows digits and underscores", () => {
+  const stream = new CharStream("π1_2");
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.value).toBe("π1_2");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("UnicodeIdentifierReader rejects starting digit", () => {
+  const stream = new CharStream("1π");
+  const start = stream.getPosition().index;
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(start);
+});
+
+test("UnicodeIdentifierReader handles ZWNJ", () => {
+  const id = "न\u200Cम";
+  const stream = new CharStream(id);
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.value).toBe(id);
+  expect(stream.getPosition().index).toBe(3);
+});


### PR DESCRIPTION
## Summary
- implement UnicodeIdentifierReader with Unicode property escapes
- mark task completed in TODO_CHECKLIST
- document UnicodeIdentifierReader in lexer spec
- test UnicodeIdentifierReader

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523f958b788331acb2c04d35d4e624