### PR TITLE
feat(reader): implement ExponentReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -68,6 +68,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
+- `ExponentReader` parses numbers like `1e5` with scientific notation.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -3,7 +3,7 @@
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
 - [x] Implement OctalReader (0o… literals)
-- [ ] Implement ExponentReader (1e… literals)
+- [x] Implement ExponentReader (1e… literals)
 - [x] Implement NumericSeparatorReader (1_000 separators)
 - [ ] Implement UnicodeIdentifierReader (full Unicode support)
 - [x] Implement ShebangReader (#!… file headers)

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -1,17 +1,33 @@
 export function ExponentReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
+
+  // must start with a digit
   if (ch === null || ch < '0' || ch > '9') return null;
 
   let value = '';
+
+  // integer part
   while (ch !== null && ch >= '0' && ch <= '9') {
     value += ch;
     stream.advance();
     ch = stream.current();
   }
 
+  // optional decimal part
+  if (ch === '.') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+    while (ch !== null && ch >= '0' && ch <= '9') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+  }
+
+  // exponent indicator
   if (ch !== 'e' && ch !== 'E') {
-    // rewind
     stream.index = startPos.index;
     return null;
   }
@@ -20,14 +36,15 @@ export function ExponentReader(stream, factory) {
   stream.advance();
   ch = stream.current();
 
+  // optional sign
   if (ch === '+' || ch === '-') {
     value += ch;
     stream.advance();
     ch = stream.current();
   }
 
+  // must have at least one digit in exponent
   if (ch === null || ch < '0' || ch > '9') {
-    // invalid exponent
     stream.index = startPos.index;
     return null;
   }

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -1,0 +1,43 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ExponentReader } from "../../src/lexer/ExponentReader.js";
+
+test("ExponentReader reads simple exponent", () => {
+  const stream = new CharStream("1e5");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1e5");
+  expect(stream.getPosition().index).toBe(3);
+});
+
+test("ExponentReader reads signed exponent", () => {
+  const stream = new CharStream("2e+7");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("2e+7");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader reads negative exponent", () => {
+  const stream = new CharStream("3e-2");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("3e-2");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader reads uppercase E and decimals", () => {
+  const stream = new CharStream("4.1E8");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("4.1E8");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("ExponentReader returns null on invalid", () => {
+  const stream = new CharStream("5e");
+  const index = stream.getPosition().index;
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition().index).toBe(index);
+});


### PR DESCRIPTION
## Summary
- add ExponentReader to parse scientific notation literals
- test ExponentReader behaviour
- document new reader in TODO checklist and lexer spec

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68523f86644c8331853b06dbad775527