### PR TITLE
feat(reader): implement ExponentReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -68,6 +68,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
+- `ExponentReader` parses numbers with `e` or `E` exponents.
 - `UnicodeIdentifierReader` reads identifiers starting with non-ASCII Unicode characters.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -3,7 +3,7 @@
 - [x] Implement HexReader (0x… literals)
 - [x] Implement BinaryReader (0b… literals)
 - [x] Implement OctalReader (0o… literals)
-- [ ] Implement ExponentReader (1e… literals)
+- [x] Implement ExponentReader (1e… literals)
 - [x] Implement NumericSeparatorReader (1_000 separators)
 - [x] Implement UnicodeIdentifierReader (full Unicode support)
 - [x] Implement ShebangReader (#!… file headers)

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -10,9 +10,19 @@ export function ExponentReader(stream, factory) {
     ch = stream.current();
   }
 
+  if (ch === '.') {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+    while (ch !== null && ch >= '0' && ch <= '9') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+  }
+
   if (ch !== 'e' && ch !== 'E') {
-    // rewind
-    stream.index = startPos.index;
+    stream.setPosition(startPos);
     return null;
   }
 
@@ -27,8 +37,7 @@ export function ExponentReader(stream, factory) {
   }
 
   if (ch === null || ch < '0' || ch > '9') {
-    // invalid exponent
-    stream.index = startPos.index;
+    stream.setPosition(startPos);
     return null;
   }
 

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -1,0 +1,36 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ExponentReader } from "../../src/lexer/ExponentReader.js";
+
+test("ExponentReader reads simple exponent", () => {
+  const stream = new CharStream("1e3");
+  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1e3");
+  expect(stream.getPosition().index).toBe(3);
+});
+
+test("ExponentReader reads decimal exponent with sign", () => {
+  const stream = new CharStream("3.5E+2");
+  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("3.5E+2");
+  expect(stream.getPosition().index).toBe(6);
+});
+
+test("ExponentReader returns null when missing digits", () => {
+  const stream = new CharStream("2e+");
+  const pos = stream.getPosition();
+  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("ExponentReader returns null when no exponent", () => {
+  const stream = new CharStream("123");
+  const pos = stream.getPosition();
+  const tok = ExponentReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+


### PR DESCRIPTION
## Summary
- implement ExponentReader for scientific notation numbers
- add tests for ExponentReader
- document ExponentReader and mark task complete

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68531cd1fc688331af8e8df46509c526