### PR TITLE
feat: add lookahead support to lexer

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -11,6 +11,7 @@ This document defines the architecture and requirements for the experimental Jav
 
 ## 3. LexerEngine <a name="lexerengine"></a>
 - Manages `stateStack`, `lookahead`
+- Provides `peek(n)` for token lookahead
 - Dispatches to token readers per `stateStack` top
 
 ## 4. Token Readers <a name="readers"></a>

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -46,3 +46,15 @@ test("nextToken rethrows reader errors", () => {
   expect(err).toBeInstanceOf(LexerError);
   expect(err.type).toBe("UnterminatedRegex");
 });
+
+test("peek returns upcoming tokens without consuming", () => {
+  const engine = new LexerEngine(new CharStream("1 + 2"));
+  expect(engine.peek().type).toBe("NUMBER");
+  // repeated peek should not consume
+  expect(engine.peek().value).toBe("1");
+  // nextToken should yield the same first token
+  expect(engine.nextToken().value).toBe("1");
+  // peek with n=2 should see the third token
+  expect(engine.peek(2).value).toBe("2");
+  expect(engine.nextToken().value).toBe("+");
+});


### PR DESCRIPTION
## Summary
- add `peek` lookahead capability to `LexerEngine`
- document new method in Lexer spec
- test lookahead behavior

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68531e54a23c8331b6a637e13df5f669