### PR TITLE
Add edge case tests for core lexer utilities

### DIFF
--- a/tests/lexerError.test.js
+++ b/tests/lexerError.test.js
@@ -18,3 +18,25 @@ test("LexerError formatting helpers", () => {
     end: { line: 1, column: 3 }
   });
 });
+
+test("LexerError context handles missing input", () => {
+  const err = new LexerError(
+    "SomeError",
+    "oops",
+    { line: 2, column: 1 },
+    { line: 2, column: 2 }
+  );
+  expect(err.context).toBe("");
+  expect(err.toString()).toContain("line 2, column 1");
+});
+
+test("LexerError context uses blank line when out of range", () => {
+  const err = new LexerError(
+    "Other",
+    "bad",
+    { line: 5, column: 2 },
+    { line: 5, column: 3 },
+    "a\nb"
+  );
+  expect(err.context).toBe("\n  ^");
+});

--- a/tests/readers/CharStream.test.js
+++ b/tests/readers/CharStream.test.js
@@ -32,3 +32,21 @@ test("CharStream setPosition restores previous position", () => {
   stream.setPosition(pos);
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("CharStream current/peek/eof handling at bounds", () => {
+  const stream = new CharStream("ab");
+  // initial position
+  expect(stream.current()).toBe("a");
+  expect(stream.peek()).toBe("b");
+  expect(stream.eof()).toBe(false);
+
+  stream.advance();
+  expect(stream.current()).toBe("b");
+  expect(stream.peek()).toBeNull();
+  expect(stream.eof()).toBe(false);
+
+  stream.advance();
+  expect(stream.current()).toBeNull();
+  expect(stream.peek()).toBeNull();
+  expect(stream.eof()).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add CharStream boundary tests for `current`, `peek`, `eof`
- expand LexerError tests to cover missing inputs and out-of-range lines

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685335fe84a08331bd99ce41e8e72886