### PR TITLE
test: enforce 100% coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,4 +2,5 @@ module.exports = {
   testEnvironment: 'node',
   // Don’t transform, we’re native ESM
   transform: {},
+  collectCoverageFrom: ['index.js'],
 };

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { fileURLToPath } from 'url';
+import { tokenize } from '../index.js';
 
 /**
  * Helper to execute the CLI entry with mocked process args.
@@ -40,4 +41,17 @@ test('CLI exits with code 1 on lexer error', async () => {
   const result = await runCli(['/abc']);
   expect(result.exitCode).toBe(1);
   expect(result.errors.length).toBeGreaterThan(0);
+});
+
+test('CLI uses empty input when none provided', async () => {
+  const result = await runCli([]);
+  expect(result.logs[0]).toEqual([]);
+  expect(result.exitCode).toBeUndefined();
+});
+
+test('tokenize logs tokens when verbose', () => {
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  tokenize('let x=1;', { verbose: true });
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- configure Jest to collect coverage from `index.js`
- add tests for CLI edge cases and verbose mode

## Testing
- `npm run lint && npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685342f1156883319993a288cf139dec