### PR TITLE
Add edge case lexer tests

### DIFF
--- a/tests/readers/CommentReader.test.js
+++ b/tests/readers/CommentReader.test.js
@@ -28,3 +28,12 @@ test("CommentReader handles unterminated block comment at EOF", () => {
   expect(token.value).toBe(src);
   expect(stream.eof()).toBe(true);
 });
+
+test("CommentReader handles line comment at EOF", () => {
+  const src = "// end";
+  const stream = new CharStream(src);
+  const token = CommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("COMMENT");
+  expect(token.value).toBe("// end");
+  expect(stream.eof()).toBe(true);
+});

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -85,3 +85,11 @@ test("RegexOrDivideReader treats newline after identifier as divide", () => {
   expect(token.type).toBe("OPERATOR");
   expect(token.value).toBe("/");
 });
+
+test("RegexOrDivideReader allows newline inside regex literal", () => {
+  const src = "/a\nb/";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe(src);
+});

--- a/tests/readers/StringReader.test.js
+++ b/tests/readers/StringReader.test.js
@@ -36,3 +36,11 @@ test("StringReader handles escapes", () => {
   expect(token.value).toBe(src);
   expect(stream.getPosition().index).toBe(src.length);
 });
+
+test("StringReader errors on newline in string", () => {
+  const src = '"a\nb"';
+  const stream = new CharStream(src);
+  const result = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(result).toBeInstanceOf(LexerError);
+  expect(result.type).toBe('UnterminatedString');
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -91,3 +91,12 @@ test("TemplateStringReader errors on unterminated expression", () => {
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe("UnterminatedTemplate");
 });
+
+test("TemplateStringReader handles nested template expressions", () => {
+  const src = "`a ${`inner ${1}`}`";
+  const stream = new CharStream(src);
+  const tok = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(tok.type).toBe("TEMPLATE_STRING");
+  expect(tok.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});


### PR DESCRIPTION
## Summary
- expand CommentReader tests for line comments at EOF
- ensure StringReader errors on newlines
- cover nested template expressions
- allow newline inside regex literal

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685347173db88331954a8d7a385a7684