### PR TITLE
Add edge case tests

### DIFF
--- a/tests/readers/BigIntReader.test.js
+++ b/tests/readers/BigIntReader.test.js
@@ -33,3 +33,19 @@ test("BigIntReader rejects prefixed binary bigints", () => {
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("BigIntReader rejects hex bigints", () => {
+  const stream = new CharStream("0x1Fn");
+  const pos = stream.getPosition();
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("BigIntReader stops before trailing digits", () => {
+  const stream = new CharStream("1n2");
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BIGINT");
+  expect(tok.value).toBe("1n");
+  expect(stream.current()).toBe("2");
+});

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -118,3 +118,11 @@ test("RegexOrDivideReader treats newline after closing paren as divide", () => {
   expect(token.type).toBe("OPERATOR");
   expect(token.value).toBe("/");
 });
+
+test("RegexOrDivideReader errors on unterminated character class", () => {
+  const src = "/[abc/";
+  const stream = new CharStream(src);
+  const result = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(result).toBeInstanceOf(LexerError);
+  expect(result.type).toBe("UnterminatedRegex");
+});

--- a/tests/readers/ShebangReader.test.js
+++ b/tests/readers/ShebangReader.test.js
@@ -42,3 +42,15 @@ test("ShebangReader handles CRLF line endings", () => {
   expect(token.value).toBe("#!/usr/bin/env node\r");
   expect(stream.current()).toBe("\n");
 });
+
+test("ShebangReader ignores BOM at start", () => {
+  const src = "\uFEFF#!/bin/bash";
+  const stream = new CharStream(src);
+  const pos = stream.getPosition();
+  const result = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(result).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+  stream.advance(); // consume BOM
+  const tok = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -110,3 +110,11 @@ test("TemplateStringReader handles CRLF line endings", () => {
   expect(stream.getPosition().index).toBe(src.length);
 });
 
+test("TemplateStringReader errors on escape at EOF", () => {
+  const src = "`abc\\"; // backslash at end
+  const stream = new CharStream(src);
+  const result = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(result).toBeInstanceOf(LexerError);
+  expect(result.type).toBe("BadEscape");
+});
+

--- a/tests/readers/UnicodeIdentifierReader.test.js
+++ b/tests/readers/UnicodeIdentifierReader.test.js
@@ -40,3 +40,11 @@ test("UnicodeIdentifierReader handles ZWJ", () => {
   expect(tok.value).toBe(id);
   expect(stream.getPosition().index).toBe(3);
 });
+
+test("UnicodeIdentifierReader returns null for ASCII start", () => {
+  const stream = new CharStream("aπ");
+  const pos = stream.getPosition();
+  const tok = UnicodeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- expand RegexOrDivideReader tests for unterminated char class
- ensure ShebangReader ignores BOM
- exercise more BigIntReader scenarios
- check TemplateStringReader escape error at EOF
- verify UnicodeIdentifierReader skips ASCII identifiers

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68534b29bb088331ae227788e6296db2