### PR TITLE
Add more edge case tests

### DIFF
--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -57,3 +57,15 @@ test("integration: hex literals", () => {
   ]);
   expect(toks[3].value).toBe("0x1A");
 });
+
+test("integration: numeric separator with exponent splits tokens", () => {
+  const toks = tokenize("let n = 1_0e3;");
+  expect(toks.map(t => t.type)).toEqual([
+    "KEYWORD",
+    "IDENTIFIER",
+    "OPERATOR",
+    "NUMBER",
+    "IDENTIFIER",
+    "PUNCTUATION"
+  ]);
+});

--- a/tests/readers/ExponentReader.test.js
+++ b/tests/readers/ExponentReader.test.js
@@ -50,3 +50,19 @@ test("ExponentReader stops before second exponent", () => {
   expect(tok.value).toBe("1e10");
   expect(stream.current()).toBe("e");
 });
+
+test("ExponentReader reads digit-dot-exponent form", () => {
+  const stream = new CharStream("1.e2");
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1.e2");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("ExponentReader rejects exponent missing digits after sign", () => {
+  const stream = new CharStream("1e+");
+  const pos = stream.getPosition();
+  const tok = ExponentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});

--- a/tests/readers/NumericSeparatorReader.test.js
+++ b/tests/readers/NumericSeparatorReader.test.js
@@ -49,3 +49,19 @@ test("NumericSeparatorReader rejects leading underscore", () => {
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("NumericSeparatorReader stops before decimal point", () => {
+  const stream = new CharStream("1_000.5");
+  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1_000");
+  expect(stream.current()).toBe(".");
+});
+
+test("NumericSeparatorReader stops before exponent", () => {
+  const stream = new CharStream("1_0e5");
+  const tok = NumericSeparatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("NUMBER");
+  expect(tok.value).toBe("1_0");
+  expect(stream.current()).toBe("e");
+});

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -126,3 +126,14 @@ test("RegexOrDivideReader errors on unterminated character class", () => {
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe("UnterminatedRegex");
 });
+
+test("RegexOrDivideReader treats slash after line comment as divide", () => {
+  const src = "a//c\n/b/";
+  const stream = new CharStream(src);
+  stream.advance(); // 'a'
+  CommentReader(stream, () => {}); // consume line comment
+  stream.advance(); // newline
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("OPERATOR");
+  expect(token.value).toBe("/");
+});

--- a/tests/readers/ShebangReader.test.js
+++ b/tests/readers/ShebangReader.test.js
@@ -54,3 +54,12 @@ test("ShebangReader ignores BOM at start", () => {
   const tok = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
   expect(tok).toBeNull();
 });
+
+test("ShebangReader consumes spaces after hashbang", () => {
+  const src = "#! /usr/bin/env node\n";
+  const stream = new CharStream(src);
+  const token = ShebangReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("COMMENT");
+  expect(token.value).toBe("#! /usr/bin/env node");
+  expect(stream.current()).toBe("\n");
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -136,3 +136,11 @@ test("TemplateStringReader handles braces inside strings", () => {
   expect(stream.getPosition().index).toBe(src.length);
 });
 
+
+test("TemplateStringReader handles escaped backtick in expression", () => {
+  const src = "`a ${`inner \\` backtick`}`";
+  const stream = new CharStream(src);
+  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("TEMPLATE_STRING");
+  expect(tok.value).toBe(src);
+});


### PR DESCRIPTION
## Summary
- add extra coverage for numeric separator handling around decimals and exponents
- test more exponent forms and invalid cases
- verify comment context for slash vs regex
- handle escaped backticks inside template strings
- accept spaces following hashbang lines
- include integration test for numeric separators with exponents

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68534e86a0448331bb3dde64586af374