### PR TITLE
Add more lexer edge case tests

### DIFF
--- a/tests/readers/BigIntReader.test.js
+++ b/tests/readers/BigIntReader.test.js
@@ -73,3 +73,35 @@ test("BigIntReader rejects trailing underscore", () => {
   expect(tok).toBeNull();
   expect(stream.getPosition()).toEqual(pos);
 });
+
+test("BigIntReader handles zero bigint", () => {
+  const stream = new CharStream("0n");
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BIGINT");
+  expect(tok.value).toBe("0n");
+  expect(stream.getPosition().index).toBe(2);
+});
+
+test("BigIntReader reads bigint with internal separators", () => {
+  const stream = new CharStream("1_2_3n");
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BIGINT");
+  expect(tok.value).toBe("1_2_3n");
+  expect(stream.getPosition().index).toBe(6);
+});
+
+test("BigIntReader rejects consecutive separators", () => {
+  const stream = new CharStream("1__2n");
+  const pos = stream.getPosition();
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("BigIntReader reads bigint with leading zeros", () => {
+  const stream = new CharStream("00n");
+  const tok = BigIntReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BIGINT");
+  expect(tok.value).toBe("00n");
+  expect(stream.getPosition().index).toBe(3);
+});

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -137,3 +137,21 @@ test("RegexOrDivideReader treats slash after line comment as divide", () => {
   expect(token.type).toBe("OPERATOR");
   expect(token.value).toBe("/");
 });
+
+test("RegexOrDivideReader handles quantifiers and groups", () => {
+  const src = "/a{2,3}(b[c]+)*/g";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});
+
+test("RegexOrDivideReader handles escaped closing bracket", () => {
+  const src = "/[a-z\\]]+/";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -144,3 +144,21 @@ test("TemplateStringReader handles escaped backtick in expression", () => {
   expect(tok.type).toBe("TEMPLATE_STRING");
   expect(tok.value).toBe(src);
 });
+
+test("TemplateStringReader allows extra closing brace", () => {
+  const src = "`a ${1}} b`";
+  const stream = new CharStream(src);
+  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("TEMPLATE_STRING");
+  expect(tok.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});
+
+test("TemplateStringReader handles deeply nested templates", () => {
+  const src = "`start ${`level1 ${`level2 ${3}`}`}`";
+  const stream = new CharStream(src);
+  const tok = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("TEMPLATE_STRING");
+  expect(tok.value).toBe(src);
+  expect(stream.getPosition().index).toBe(src.length);
+});


### PR DESCRIPTION
## Summary
- extend `BigIntReader` tests for separators and leading zeros
- add nested/extra brace cases for `TemplateStringReader`
- expand `RegexOrDivideReader` tests with complex patterns

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68534fc9ada88331909d4135a0807af1