### PR TITLE
Add TypeScript decorator plugin example

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -34,3 +34,35 @@ const tokens = tokenize('#');
 ```
 
 Use `clearPlugins()` to remove all registered plugins, typically in tests.
+
+## Example: TypeScript Decorators
+
+Plugins can extend the lexer to handle TypeScript or Flow syntax. This example
+adds support for decorator tokens beginning with `@`:
+
+```javascript
+export function TSDecoratorReader(stream, factory) {
+  const pos = stream.getPosition();
+  if (stream.current() !== '@') return null;
+  let val = '@';
+  stream.advance();
+  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
+    val += stream.current();
+    stream.advance();
+  }
+  return factory('DECORATOR', val, pos, stream.getPosition());
+}
+
+export const TSDecoratorPlugin = {
+  modes: { default: [TSDecoratorReader] },
+  init(engine) {
+    /* engine tweaks */
+  }
+};
+```
+
+Register the plugin in the same way:
+
+```javascript
+registerPlugin(TSDecoratorPlugin);
+```

--- a/src/plugins/DecoratorPlugin.js
+++ b/src/plugins/DecoratorPlugin.js
@@ -1,0 +1,18 @@
+export function TSDecoratorReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== '@') return null;
+  let val = '@';
+  stream.advance();
+  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
+    val += stream.current();
+    stream.advance();
+  }
+  return factory('DECORATOR', val, start, stream.getPosition());
+}
+
+export const DecoratorPlugin = {
+  modes: { default: [TSDecoratorReader] },
+  init() {
+    // plugin hook for future engine tweaks
+  }
+};

--- a/tests/decoratorPlugin.test.js
+++ b/tests/decoratorPlugin.test.js
@@ -1,0 +1,16 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { registerPlugin, clearPlugins } from '../index.js';
+import { DecoratorPlugin } from '../src/plugins/DecoratorPlugin.js';
+
+afterEach(() => {
+  clearPlugins();
+});
+
+test('TSDecoratorReader recognizes decorators', () => {
+  registerPlugin(DecoratorPlugin);
+  const engine = new LexerEngine(new CharStream('@Component'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('DECORATOR');
+  expect(tok.value).toBe('@Component');
+});


### PR DESCRIPTION
## Summary
- add a DecoratorPlugin for TypeScript decorator tokens
- include a test for the new plugin
- document the plugin in the Plugin API docs

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68535669623c8331a84e626c4cb19082