### PR TITLE
Add whitespace token and trivia tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,23 @@ export function tokenize(code, { verbose = false } = {}) {
   const stream = new CharStream(code);
   const lexer = new LexerEngine(stream);
   const tokens = [];
-  // eslint-disable-next-line no-constant-condition
+  let trivia = [];
+  let prev = null;
   while (true) {
     const tok = lexer.nextToken();
     if (tok === null) break;
+    if (tok.type === 'WHITESPACE') {
+      trivia.push(tok);
+      continue;
+    }
+    tok.trivia.leading = trivia;
+    if (prev) prev.trivia.trailing = trivia;
+    trivia = [];
     tokens.push(tok);
+    prev = tok;
     if (verbose) console.log(tok);
   }
+  if (prev) prev.trivia.trailing = trivia;
   return tokens;
 }
 

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -12,6 +12,7 @@ export class BufferedIncrementalLexer {
     this.tokens = [];
     this.stream = new CharStream('');
     this.engine = new LexerEngine(this.stream);
+    this.trivia = [];
   }
 
   /**
@@ -46,6 +47,15 @@ export class BufferedIncrementalLexer {
         this.stream.setPosition(pos);
         break;
       }
+      if (token.type === 'WHITESPACE') {
+        this.trivia.push(token);
+        continue;
+      }
+      token.trivia.leading = this.trivia;
+      if (this.tokens.length > 0) {
+        this.tokens[this.tokens.length - 1].trivia.trailing = this.trivia;
+      }
+      this.trivia = [];
       this.tokens.push(token);
       this.onToken(token);
     }

--- a/src/integration/IncrementalLexer.js
+++ b/src/integration/IncrementalLexer.js
@@ -19,9 +19,22 @@ export class IncrementalLexer {
   feed(chunk) {
     this.stream.input += chunk;
     let token;
+    let trivia = [];
     while ((token = this.engine.nextToken()) !== null) {
+      if (token.type === 'WHITESPACE') {
+        trivia.push(token);
+        continue;
+      }
+      token.trivia.leading = trivia;
+      if (this.tokens.length > 0) {
+        this.tokens[this.tokens.length - 1].trivia.trailing = trivia;
+      }
+      trivia = [];
       this.tokens.push(token);
       this.onToken(token);
+    }
+    if (this.tokens.length > 0) {
+      this.tokens[this.tokens.length - 1].trivia.trailing = trivia;
     }
   }
 

--- a/src/lexer/Token.js
+++ b/src/lexer/Token.js
@@ -7,6 +7,7 @@ export class Token {
     this.value = value;
     this.start = start;
     this.end = end;
+    this.trivia = { leading: [], trailing: [] };
   }
   toJSON() {
     return { type: this.type, value: this.value, start: this.start, end: this.end };

--- a/src/lexer/WhitespaceReader.js
+++ b/src/lexer/WhitespaceReader.js
@@ -1,14 +1,18 @@
 /**
  * §4.7 WhitespaceReader
- * Consumes consecutive whitespace characters.
- * Does not emit a token; callers may attach trivia if needed.
+ * Consumes consecutive whitespace characters and returns a WHITESPACE token.
  */
 const WHITESPACE = new Set([' ', '\n', '\t', '\r', '\v', '\f']);
 
-export function WhitespaceReader(stream) {
+export function WhitespaceReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (!WHITESPACE.has(stream.current())) return null;
+
+  let value = '';
   while (!stream.eof() && WHITESPACE.has(stream.current())) {
+    value += stream.current();
     stream.advance();
   }
-  // No token is returned for whitespace.
-  return null;
+  const endPos = stream.getPosition();
+  return factory('WHITESPACE', value, startPos, endPos);
 }

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -54,7 +54,13 @@ test("peek returns upcoming tokens without consuming", () => {
   expect(engine.peek().value).toBe("1");
   // nextToken should yield the same first token
   expect(engine.nextToken().value).toBe("1");
-  // peek with n=2 should see the third token
-  expect(engine.peek(2).value).toBe("2");
+  // whitespace token follows
+  expect(engine.peek().type).toBe("WHITESPACE");
+  // peek with n=2 should see the operator
+  expect(engine.peek(2).value).toBe("+");
+  // peek with n=4 should see the final number
+  expect(engine.peek(4).value).toBe("2");
+  // consume whitespace then operator
+  expect(engine.nextToken().type).toBe("WHITESPACE");
   expect(engine.nextToken().value).toBe("+");
 });

--- a/tests/readers/WhitespaceReader.test.js
+++ b/tests/readers/WhitespaceReader.test.js
@@ -1,18 +1,21 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
 import { WhitespaceReader } from "../../src/lexer/WhitespaceReader.js";
 
-test("WhitespaceReader skips consecutive whitespace", () => {
+test("WhitespaceReader reads consecutive spaces", () => {
   const stream = new CharStream("   abc");
-  const token = WhitespaceReader(stream, () => {});
-  expect(token).toBeNull();
+  const token = WhitespaceReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("WHITESPACE");
+  expect(token.value).toBe("   ");
   expect(stream.getPosition().index).toBe(3);
   expect(stream.current()).toBe("a");
 });
 
 test("WhitespaceReader handles mixed whitespace characters", () => {
   const stream = new CharStream(" \t\n\r\v\fabc");
-  const token = WhitespaceReader(stream, () => {});
-  expect(token).toBeNull();
+  const token = WhitespaceReader(stream, (t, v, s, e) => new Token(t, v, s, e));
+  expect(token.type).toBe("WHITESPACE");
+  expect(token.value).toBe(" \t\n\r\v\f");
   expect(stream.getPosition().index).toBe(6);
   expect(stream.current()).toBe("a");
 });


### PR DESCRIPTION
## Summary
- return `WHITESPACE` tokens from `WhitespaceReader`
- store leading and trailing trivia in `Token`
- attach whitespace trivia when tokenizing
- update engine tests and whitespace reader tests
- preserve comment tokens while filtering whitespace

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685359092c848331903e0c8c0f4bda83