### PR TITLE
feat: handle unicode escape identifiers

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -71,6 +71,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `ExponentReader` parses numbers with `e` or `E` exponents.
 - `UnicodeIdentifierReader` reads identifiers starting with non-ASCII Unicode characters.
+- `UnicodeEscapeIdentifierReader` reads identifiers containing Unicode escape sequences like `\u{1F600}`.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -15,6 +15,7 @@ import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
+import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
@@ -47,6 +48,7 @@ export class LexerEngine {
         ShebangReader,
         IdentifierReader,
         UnicodeIdentifierReader,
+        UnicodeEscapeIdentifierReader,
         HexReader,
         BinaryReader,
         OctalReader,

--- a/src/lexer/UnicodeEscapeIdentifierReader.js
+++ b/src/lexer/UnicodeEscapeIdentifierReader.js
@@ -1,0 +1,68 @@
+const ID_START_RE = /[\p{ID_Start}\p{Math}\p{Emoji}$_]/u;
+const ID_CONTINUE_RE = /[\p{ID_Continue}\p{Math}\p{Emoji}$_\u200C\u200D]/u;
+
+function readUnicodeEscape(stream) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '\\' || stream.peek() !== 'u') return null;
+  stream.advance(); // '\\'
+  stream.advance(); // 'u'
+
+  let codePoint = 0;
+  if (stream.current() === '{') {
+    stream.advance();
+    let digits = '';
+    while (!stream.eof() && /[0-9a-fA-F]/.test(stream.current())) {
+      digits += stream.current();
+      stream.advance();
+    }
+    if (stream.current() !== '}' || digits.length === 0 || digits.length > 6) {
+      stream.setPosition(startPos);
+      return null;
+    }
+    stream.advance(); // consume '}'
+    codePoint = parseInt(digits, 16);
+  } else {
+    let digits = '';
+    for (let i = 0; i < 4; i++) {
+      const ch = stream.current();
+      if (!/[0-9a-fA-F]/.test(ch)) {
+        stream.setPosition(startPos);
+        return null;
+      }
+      digits += ch;
+      stream.advance();
+    }
+    codePoint = parseInt(digits, 16);
+  }
+  return String.fromCodePoint(codePoint);
+}
+
+export function UnicodeEscapeIdentifierReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const first = readUnicodeEscape(stream);
+  if (!first || !ID_START_RE.test(first)) {
+    if (first) stream.setPosition(startPos);
+    return null;
+  }
+  let value = first;
+  let ch = stream.current();
+  while (ch !== null) {
+    if (ch === '\\' && stream.peek() === 'u') {
+      const escStart = stream.getPosition();
+      const cp = readUnicodeEscape(stream);
+      if (!cp || !ID_CONTINUE_RE.test(cp)) {
+        stream.setPosition(escStart);
+        break;
+      }
+      value += cp;
+      ch = stream.current();
+      continue;
+    }
+    if (!ID_CONTINUE_RE.test(ch)) break;
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const endPos = stream.getPosition();
+  return factory('IDENTIFIER', value, startPos, endPos);
+}

--- a/src/lexer/UnicodeIdentifierReader.js
+++ b/src/lexer/UnicodeIdentifierReader.js
@@ -1,5 +1,5 @@
-const ID_START_RE = /[\p{ID_Start}$_]/u;
-const ID_CONTINUE_RE = /[\p{ID_Continue}$_\u200C\u200D]/u;
+const ID_START_RE = /[\p{ID_Start}\p{Math}\p{Emoji}$_]/u;
+const ID_CONTINUE_RE = /[\p{ID_Continue}\p{Math}\p{Emoji}$_\u200C\u200D]/u;
 
 export function UnicodeIdentifierReader(stream, factory) {
   const startPos = stream.getPosition();

--- a/tests/fuzz.test.js
+++ b/tests/fuzz.test.js
@@ -17,6 +17,7 @@ import { OctalReader } from "../src/lexer/OctalReader.js";
 import { ExponentReader } from "../src/lexer/ExponentReader.js";
 import { NumericSeparatorReader } from "../src/lexer/NumericSeparatorReader.js";
 import { UnicodeIdentifierReader } from "../src/lexer/UnicodeIdentifierReader.js";
+import { UnicodeEscapeIdentifierReader } from "../src/lexer/UnicodeEscapeIdentifierReader.js";
 import { ShebangReader } from "../src/lexer/ShebangReader.js";
 
 function randomAsciiString(maxLen = 20) {
@@ -44,6 +45,7 @@ const READERS = [
   ["ExponentReader", ExponentReader],
   ["NumericSeparatorReader", NumericSeparatorReader],
   ["UnicodeIdentifierReader", UnicodeIdentifierReader],
+  ["UnicodeEscapeIdentifierReader", UnicodeEscapeIdentifierReader],
   ["ShebangReader", ShebangReader],
 ];
 

--- a/tests/readers/UnicodeEscapeIdentifierReader.test.js
+++ b/tests/readers/UnicodeEscapeIdentifierReader.test.js
@@ -1,0 +1,26 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { UnicodeEscapeIdentifierReader } from "../../src/lexer/UnicodeEscapeIdentifierReader.js";
+
+test("UnicodeEscapeIdentifierReader reads escape identifier", () => {
+  const stream = new CharStream("\\u0061bc");
+  const tok = UnicodeEscapeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("IDENTIFIER");
+  expect(tok.value).toBe("abc");
+  expect(stream.getPosition().index).toBe(8);
+});
+
+test("UnicodeEscapeIdentifierReader handles codepoint escape", () => {
+  const stream = new CharStream("\\u{1F600}_end");
+  const tok = UnicodeEscapeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.value).toBe("😀_end");
+  expect(stream.getPosition().index).toBe(13);
+});
+
+test("UnicodeEscapeIdentifierReader returns null for bad escape", () => {
+  const stream = new CharStream("\\uXYZ");
+  const pos = stream.getPosition();
+  const tok = UnicodeEscapeIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- broaden unicode identifier reader to accept math symbols and emoji
- add UnicodeEscapeIdentifierReader for `\u{...}` sequences
- wire new reader into LexerEngine and fuzz tests
- document new reader in lexer spec
- test UnicodeEscapeIdentifierReader

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685358b85a988331bda59d176b5cf983