### PR TITLE
feat: enhance JSX and template lexing

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -65,6 +65,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - Character classes inside regex literals are parsed, ignoring `/` characters
   until the closing `]`.
 - Template strings track nested `${ ... }` braces and handle escapes.
+- `HTML_TEMPLATE_STRING` tokens are returned for `html`-tagged templates.
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
@@ -74,6 +75,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
+- `JSXReader` ignores `<` inside `{}` expressions and supports self-closing tags.
 
 ## 11. Usage Examples <a name="examples"></a>
 Run the CLI directly:

--- a/src/lexer/JSXReader.js
+++ b/src/lexer/JSXReader.js
@@ -8,43 +8,76 @@ export function JSXReader(stream, factory, engine) {
   const startPos = stream.getPosition();
   let value = '';
   let depth = 0;
+  let braceDepth = 0;
+  let quote = null;
 
   while (!stream.eof()) {
     const ch = stream.current();
     value += ch;
-    if (ch === '<') {
-      depth++;
-    } else if (ch === '>') {
-      depth--;
-      stream.advance();
-      if (depth <= 0) {
-        const endPos = stream.getPosition();
-        engine && engine.popMode && engine.popMode();
-        return factory('JSX_TEXT', value, startPos, endPos);
-      }
-      continue;
-    } else if (ch === '"' || ch === "'") {
-      const quote = ch;
-      stream.advance();
-      while (!stream.eof()) {
-        const qch = stream.current();
-        value += qch;
-        if (qch === '\\') {
-          stream.advance();
-          if (!stream.eof()) {
-            value += stream.current();
-            stream.advance();
-          }
-          continue;
-        }
-        if (qch === quote) {
-          stream.advance();
-          break;
-        }
+
+    if (quote) {
+      if (ch === '\\') {
         stream.advance();
+        if (!stream.eof()) {
+          value += stream.current();
+          stream.advance();
+        }
+        continue;
       }
+      if (ch === quote) {
+        quote = null;
+      }
+      stream.advance();
       continue;
     }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      stream.advance();
+      continue;
+    }
+
+    if (ch === '{') {
+      braceDepth++;
+      stream.advance();
+      continue;
+    }
+    if (ch === '}') {
+      if (braceDepth > 0) braceDepth--;
+      stream.advance();
+      continue;
+    }
+
+    if (braceDepth === 0) {
+      if (ch === '<') {
+        depth++;
+        stream.advance();
+        continue;
+      }
+      if (ch === '/' && stream.peek() === '>') {
+        stream.advance();
+        value += '>';
+        stream.advance();
+        depth--;
+        if (depth <= 0) {
+          const endPos = stream.getPosition();
+          engine && engine.popMode && engine.popMode();
+          return factory('JSX_TEXT', value, startPos, endPos);
+        }
+        continue;
+      }
+      if (ch === '>') {
+        depth--;
+        stream.advance();
+        if (depth <= 0) {
+          const endPos = stream.getPosition();
+          engine && engine.popMode && engine.popMode();
+          return factory('JSX_TEXT', value, startPos, endPos);
+        }
+        continue;
+      }
+    }
+
     stream.advance();
   }
 

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -115,8 +115,11 @@ export class LexerEngine {
       // 1. Mode switching for JSX
       let mode = this.currentMode();
       if (mode === 'default' && stream.current() === '<') {
-        this.pushMode('jsx');
-        mode = this.currentMode();
+        const next = stream.peek();
+        if (/[A-Za-z\/!?]|>/.test(next)) {
+          this.pushMode('jsx');
+          mode = this.currentMode();
+        }
       }
 
       const readers = this.modes[mode] || this.modes.default;

--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -4,9 +4,15 @@
 // full raw value or null if the stream isn’t at a backtick.
 import { LexerError } from './LexerError.js';
 
-export function TemplateStringReader(stream, factory) {
+export function TemplateStringReader(stream, factory, engine) {
   const startPos = stream.getPosition();
   if (stream.current() !== '`') return null;
+
+  const isHTMLTagged =
+    engine &&
+    engine.lastToken &&
+    engine.lastToken.type === 'IDENTIFIER' &&
+    engine.lastToken.value === 'html';
 
   let value = '';
   // consume opening backtick
@@ -40,7 +46,12 @@ export function TemplateStringReader(stream, factory) {
       value += '`';
       stream.advance();
       const endPos = stream.getPosition();
-      return factory('TEMPLATE_STRING', value, startPos, endPos);
+      return factory(
+        isHTMLTagged ? 'HTML_TEMPLATE_STRING' : 'TEMPLATE_STRING',
+        value,
+        startPos,
+        endPos
+      );
     }
 
     // embedded expression `${ ... }`

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -35,6 +35,16 @@ test("nextToken auto-enables JSX mode", () => {
   expect(engine.currentMode()).toBe("default");
 });
 
+test("nextToken does not treat comparison as JSX", () => {
+  const engine = new LexerEngine(new CharStream("a < b"));
+  const t1 = engine.nextToken();
+  const t2 = engine.nextToken();
+  const t3 = engine.nextToken();
+  expect(t1.type).toBe("IDENTIFIER");
+  expect(t2.value).toBe("<");
+  expect(t3.type).toBe("IDENTIFIER");
+});
+
 test("nextToken rethrows reader errors", () => {
   const engine = new LexerEngine(new CharStream("/abc"));
   let err;

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -16,6 +16,15 @@ test("TemplateStringReader reads template with interpolation", () => {
   expect(stream.getPosition().index).toBe(src.length);
 });
 
+test("TemplateStringReader produces HTML_TEMPLATE_STRING when tagged", () => {
+  const src = "`<div>${x}</div>`";
+  const stream = new CharStream(src);
+  const engine = { lastToken: new Token("IDENTIFIER", "html", { index: 0 }, { index: 4 }) };
+  const tok = TemplateStringReader(stream, (t, v, s, e) => new Token(t, v, s, e), engine);
+  expect(tok.type).toBe("HTML_TEMPLATE_STRING");
+  expect(tok.value).toBe(src);
+});
+
 test("TemplateStringReader returns null for non-backtick start", () => {
   const stream = new CharStream("'not template'");
   const result = TemplateStringReader(


### PR DESCRIPTION
## Summary
- improve heuristic for JSX mode switching
- handle braces and self-closing tags in JSXReader
- mark html tagged templates as `HTML_TEMPLATE_STRING`
- document new behavior
- add regression tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test -- --coverage` *(fails: missing Jest module)*

------
https://chatgpt.com/codex/tasks/task_e_685358dfbd3c83318d7caa710f4aa31e