### PR TITLE
feat: add recovery tokens for regex and escapes

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -56,9 +56,9 @@ Each is a pure function `(stream, factory) => Token|null`:
 - Agent prompts: `.codex/promptMap.json`
 
 ## 10. Edge Cases & Error Handling <a name="edge"></a>
-- Unterminated regex literals yield a `LexerError` of type `UnterminatedRegex`.
-- Unterminated template literals yield a `LexerError` of type `UnterminatedTemplate`.
-- Bad escape sequences inside template strings produce a `LexerError` of type `BadEscape`.
+- Unterminated regex literals emit an `INVALID_REGEX` token instead of throwing.
+- Bad escape sequences in strings or template literals emit an `INVALID_ESCAPE` token.
+- Unterminated template literals still yield a `LexerError` of type `UnterminatedTemplate`.
 - Multi-line comments reaching EOF are returned as `COMMENT` tokens without error.
 - `/=` is always tokenized as the divide-assign operator before regex detection.
 - Regex or divide context is inferred from the last non-whitespace character.

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -37,6 +37,14 @@ export class BufferedIncrementalLexer {
       }
       if (token === null) break;
       if (
+        (token.type === 'INVALID_REGEX' || token.type === 'INVALID_ESCAPE') &&
+        this.stream.eof()
+      ) {
+        // Incomplete token, rewind and wait for more input
+        this.stream.setPosition(pos);
+        break;
+      }
+      if (
         token.type === 'COMMENT' &&
         token.value.startsWith('/*') &&
         !token.value.endsWith('*/') &&

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -1,6 +1,5 @@
 // §4.5 RegexOrDivideReader
 // Context-sensitive reader: decides whether a “/” starts a RegExp literal or is a divide operator.
-import { LexerError } from './LexerError.js';
 
 export function RegexOrDivideReader(stream, factory) {
   const startPos = stream.getPosition();
@@ -95,14 +94,10 @@ export function RegexOrDivideReader(stream, factory) {
   }
 
   if (stream.current() !== '/') {
-    // Unterminated regex
-    return new LexerError(
-      'UnterminatedRegex',
-      'Unterminated regular expression literal',
-      startPos,
-      stream.getPosition(),
-      stream.input
-    );
+    // Unterminated regex - emit invalid token instead of error
+    const endPos = stream.getPosition();
+    const value = stream.input.slice(startPos.index, endPos.index);
+    return factory('INVALID_REGEX', value, startPos, endPos);
   }
 
   stream.advance(); // consume closing '/'

--- a/src/lexer/StringReader.js
+++ b/src/lexer/StringReader.js
@@ -16,12 +16,12 @@ export function StringReader(stream, factory) {
       value += ch;
       stream.advance();
       if (stream.eof()) {
-        return new LexerError(
-          'BadEscape',
-          'Bad escape sequence in string literal',
+        const endPos = stream.getPosition();
+        return factory(
+          'INVALID_ESCAPE',
+          stream.input.slice(startPos.index, endPos.index),
           startPos,
-          stream.getPosition(),
-          stream.input
+          endPos
         );
       }
       value += stream.current();

--- a/src/lexer/TemplateStringReader.js
+++ b/src/lexer/TemplateStringReader.js
@@ -22,12 +22,12 @@ export function TemplateStringReader(stream, factory) {
       value += ch;
       stream.advance();
       if (stream.eof()) {
-        return new LexerError(
-          'BadEscape',
-          'Bad escape sequence in template literal',
+        const endPos = stream.getPosition();
+        return factory(
+          'INVALID_ESCAPE',
+          stream.input.slice(escStart.index, endPos.index),
           escStart,
-          stream.getPosition(),
-          stream.input
+          endPos
         );
       }
       value += stream.current();

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -37,8 +37,14 @@ test('CLI prints tokens array for valid input', async () => {
   expect(result.exitCode).toBeUndefined();
 });
 
-test('CLI exits with code 1 on lexer error', async () => {
+test('CLI outputs INVALID_REGEX token for bad input', async () => {
   const result = await runCli(['/abc']);
+  expect(result.exitCode).toBeUndefined();
+  expect(result.logs[0][0].type).toBe('INVALID_REGEX');
+});
+
+test('CLI exits with code 1 on template error', async () => {
+  const result = await runCli(['`unterminated']);
   expect(result.exitCode).toBe(1);
   expect(result.errors.length).toBeGreaterThan(0);
 });

--- a/tests/engine.test.js
+++ b/tests/engine.test.js
@@ -2,7 +2,6 @@ import { jest } from "@jest/globals";
 import { CharStream } from "../src/lexer/CharStream.js";
 import { LexerEngine } from "../src/lexer/LexerEngine.js";
 
-import { LexerError } from "../src/lexer/LexerError.js";
 test("LexerEngine pushMode and popMode manage state stack", () => {
   const engine = new LexerEngine(new CharStream(""));
   expect(engine.currentMode()).toBe("default");
@@ -35,16 +34,10 @@ test("nextToken auto-enables JSX mode", () => {
   expect(engine.currentMode()).toBe("default");
 });
 
-test("nextToken rethrows reader errors", () => {
+test("nextToken returns INVALID_REGEX token instead of throwing", () => {
   const engine = new LexerEngine(new CharStream("/abc"));
-  let err;
-  try {
-    engine.nextToken();
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeInstanceOf(LexerError);
-  expect(err.type).toBe("UnterminatedRegex");
+  const tok = engine.nextToken();
+  expect(tok.type).toBe("INVALID_REGEX");
 });
 
 test("peek returns upcoming tokens without consuming", () => {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -23,8 +23,9 @@ test("integration: trailing whitespace does not produce null token", () => {
   ]);
 });
 
-test("integration: tokenize throws on unterminated regex", () => {
-  expect(() => tokenize("/abc")).toThrow();
+test("integration: tokenize returns INVALID_REGEX token", () => {
+  const toks = tokenize("/abc");
+  expect(toks[0].type).toBe("INVALID_REGEX");
 });
 
 test("integration: tokenize throws on unterminated template", () => {

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -1,7 +1,6 @@
 import { CharStream } from "../../src/lexer/CharStream.js";
 import { Token } from "../../src/lexer/Token.js";
 import { RegexOrDivideReader } from "../../src/lexer/RegexOrDivideReader.js";
-import { LexerError } from "../../src/lexer/LexerError.js";
 
 import { CommentReader } from "../../src/lexer/CommentReader.js";
 test("RegexOrDivideReader reads regex literal", () => {
@@ -30,12 +29,11 @@ test("RegexOrDivideReader reads '/=' operator", () => {
   expect(stream.getPosition().index).toBe(2);
 });
 
-test("RegexOrDivideReader returns LexerError on unterminated regex", () => {
+test("RegexOrDivideReader returns INVALID_REGEX token on unterminated regex", () => {
   const stream = new CharStream("/abc");
   const result = RegexOrDivideReader(stream, (t, v, s, e) => new Token(t, v, s, e));
-  expect(result).toBeInstanceOf(LexerError);
-  expect(result.type).toBe("UnterminatedRegex");
-  expect(result.toString()).toContain("line 1, column 0");
+  expect(result.type).toBe("INVALID_REGEX");
+  expect(result.value).toBe("/abc");
 });
 
 test("RegexOrDivideReader handles escaped slashes", () => {
@@ -119,12 +117,12 @@ test("RegexOrDivideReader treats newline after closing paren as divide", () => {
   expect(token.value).toBe("/");
 });
 
-test("RegexOrDivideReader errors on unterminated character class", () => {
+test("RegexOrDivideReader returns INVALID_REGEX token on unterminated character class", () => {
   const src = "/[abc/";
   const stream = new CharStream(src);
   const result = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(result).toBeInstanceOf(LexerError);
-  expect(result.type).toBe("UnterminatedRegex");
+  expect(result.type).toBe("INVALID_REGEX");
+  expect(result.value).toBe(src);
 });
 
 test("RegexOrDivideReader treats slash after line comment as divide", () => {

--- a/tests/readers/StringReader.test.js
+++ b/tests/readers/StringReader.test.js
@@ -44,3 +44,11 @@ test("StringReader errors on newline in string", () => {
   expect(result).toBeInstanceOf(LexerError);
   expect(result.type).toBe('UnterminatedString');
 });
+
+test("StringReader returns INVALID_ESCAPE token on escape at EOF", () => {
+  const src = '"abc\\';
+  const stream = new CharStream(src);
+  const result = StringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(result.type).toBe('INVALID_ESCAPE');
+  expect(result.value).toBe(src);
+});

--- a/tests/readers/TemplateStringReader.test.js
+++ b/tests/readers/TemplateStringReader.test.js
@@ -37,15 +37,14 @@ test("TemplateStringReader returns LexerError on unterminated template", () => {
   expect(result.toString()).toContain('line 1, column 0');
 });
 
-test("TemplateStringReader returns LexerError on bad escape", () => {
+test("TemplateStringReader returns INVALID_ESCAPE token on bad escape", () => {
   const stream = new CharStream('`bad \\');
   const result = TemplateStringReader(
     stream,
     (type, value, start, end) => new Token(type, value, start, end)
   );
-  expect(result).toBeInstanceOf(LexerError);
-  expect(result.type).toBe('BadEscape');
-  expect(result.toString()).toContain('line 1, column 5');
+  expect(result.type).toBe('INVALID_ESCAPE');
+  expect(result.value).toBe('\\');
 });
 
 test("TemplateStringReader handles escapes and nested braces", () => {
@@ -110,12 +109,12 @@ test("TemplateStringReader handles CRLF line endings", () => {
   expect(stream.getPosition().index).toBe(src.length);
 });
 
-test("TemplateStringReader errors on escape at EOF", () => {
+test("TemplateStringReader returns INVALID_ESCAPE token on escape at EOF", () => {
   const src = "`abc\\"; // backslash at end
   const stream = new CharStream(src);
   const result = TemplateStringReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(result).toBeInstanceOf(LexerError);
-  expect(result.type).toBe("BadEscape");
+  expect(result.type).toBe("INVALID_ESCAPE");
+  expect(result.value).toBe("\\");
 });
 
 test("TemplateStringReader handles empty template", () => {


### PR DESCRIPTION
## Summary
- add INVALID_REGEX and INVALID_ESCAPE recovery tokens
- allow BufferedIncrementalLexer to buffer invalid tokens
- update tests for new recovery behavior
- document new error recovery tokens

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68535940507083319d62983b924c3a92