### PR TITLE
Improve setup docs and mark tasks done

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,14 +1,15 @@
 # Quick Start
 
-1. Install dependencies:
+1. Use Node.js 18 or higher.
+2. Install dependencies:
    ```bash
    npm install
    ```
-2. Run tests:
+3. Run tests:
    ```bash
    npm test
    ```
-3. Lex a file:
+4. Lex a file:
    ```bash
    node index.js "let x = 42;"
    ```

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -3,11 +3,11 @@
 This document outlines detailed subtasks for each remaining objective in `TODO_CHECKLIST.md`.
 
 ## 12. Extended Reader Support
-- [ ] Implement a `JSXReader` capable of tokenizing JSX syntax.
-- [ ] Add a `jsx` mode in `LexerEngine` and dispatch to `JSXReader`.
-- [ ] Support advanced string literals (multi-line, escape forms) in a dedicated reader.
-- [ ] Update unit tests covering JSX and new string literals.
-- [ ] Document usage and edge cases in `docs/LEXER_SPEC.md`.
+- [x] Implement a `JSXReader` capable of tokenizing JSX syntax.
+- [x] Add a `jsx` mode in `LexerEngine` and dispatch to `JSXReader`.
+- [x] Support advanced string literals (multi-line, escape forms) in a dedicated reader.
+- [x] Update unit tests covering JSX and new string literals.
+- [x] Document usage and edge cases in `docs/LEXER_SPEC.md`.
 
 ## 13. ECMAScript Coverage
 - [x] Create readers for remaining ECMAScript features (e.g. bigints, optional chaining, nullish coalescing).

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "@jest/globals": "^29.0.0",
     "@commitlint/cli": "^17.0.0",
     "@commitlint/config-conventional": "^17.0.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- document Node.js requirement in Quick Start
- record that extended reader tasks are complete
- enforce Node >=18 in `package.json`

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68536299ac148331b522579e2b3225bc