### PR TITLE
Add project board sync and pre-commit

### DIFF
--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { Octokit } from '@octokit/rest';
+
+const token = process.env.GITHUB_TOKEN;
+const repoFull = process.env.GITHUB_REPOSITORY;
+const boardName = process.env.PROJECT_NAME || 'Experimental Lexer';
+const columns = ['Todo', 'In Progress', 'Review', 'Done'];
+
+if (!token || !repoFull) {
+  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY env vars required');
+  process.exit(1);
+}
+
+const [owner, repo] = repoFull.split('/');
+const octokit = new Octokit({ auth: token });
+
+async function ensureBoard() {
+  const { data: projects } = await octokit.rest.projects.listForRepo({ owner, repo });
+  let project = projects.find(p => p.name === boardName);
+  if (!project) {
+    project = (await octokit.rest.projects.createForRepo({ owner, repo, name: boardName })).data;
+    console.log(`Created board: ${boardName}`);
+  } else {
+    console.log(`Board exists: ${boardName}`);
+  }
+
+  const { data: existingCols } = await octokit.rest.projects.listColumns({ project_id: project.id });
+  const names = existingCols.map(c => c.name);
+  for (const name of columns) {
+    if (!names.includes(name)) {
+      await octokit.rest.projects.createColumn({ project_id: project.id, name });
+      console.log(`Added column ${name}`);
+    }
+  }
+}
+
+ensureBoard().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,0 +1,24 @@
+name: Sync TODO with Project Board
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  push:
+    paths:
+      - 'docs/TODO_CHECKLIST.md'
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: node .github/scripts/setup-project-board.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+      - run: node .github/scripts/seed-todo.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint && npm test -- --coverage

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ A modular, adaptive, experimental JavaScript lexer designed for autonomous devel
 
 See `QUICK_START.md` for setup and development guidelines.
 
+### Pre-commit
+Run `npm install` once to set up Husky hooks. Commits will automatically run
+`npm run lint` and `npm test` before being created.
+
 ## Project Board
 
 Track progress and self-assign tasks on the [GitHub Project Board](https://github.com/your-org/experimental-js-lexer/projects/1).
+The `setup-project-board.js` helper ensures a board with `Todo`, `In Progress`,
+`Review`, and `Done` columns exists. Running the `seed-todo.js` script will
+create issues from `docs/TODO_CHECKLIST.md` and place them in the **Todo**
+column automatically.
 
 ## Code of Conduct
 

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -120,3 +120,9 @@ LexerEngine.registerPlugin(HashPlugin);
 
 Plugins may provide readers for any mode using a `modes` map and an optional
 `init(engine)` hook. See `docs/PLUGIN_API.md` for a full example.
+
+## 13. Pipeline Operator <a name="pipeline"></a>
+The experimental lexer will recognize the pipeline operator `|>` as a distinct `PIPELINE_OPERATOR` token. This reader should emit the token when the `|>` sequence is encountered in default mode. Future versions may support additional pipeline styles.
+
+## 14. Do Expressions <a name="do-expressions"></a>
+Do expressions allow block scoped evaluation returning the last statement value. The lexer must produce `DO_BLOCK_START` and `DO_BLOCK_END` tokens around the `do { ... }` body and handle nesting via the state stack.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,11 @@
         "@commitlint/config-conventional": "^17.0.0",
         "@jest/globals": "^29.0.0",
         "eslint": "^8.0.0",
+        "husky": "^9.1.7",
         "jest": "^29.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3944,6 +3948,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
     "bench": "node tests/benchmarks/lexer.bench.js",
     "build": "echo \"Nothing to build\"",
-    "prepare": "npm run lint",
+    "prepare": "node scripts/prepare-husky.cjs",
     "build:extension": "npm --prefix extension install && npm --prefix extension run build",
-    "publish:extension": "npm --prefix extension install && npm --prefix extension run publish"
+    "publish:extension": "npm --prefix extension install && npm --prefix extension run publish",
+    "sync:project": "node .github/scripts/setup-project-board.js && node .github/scripts/seed-todo.js"
   },
   "keywords": [
     "lexer",
@@ -22,13 +23,13 @@
   ],
   "author": "",
   "license": "MIT",
-  "dependencies": {},
   "devDependencies": {
-    "eslint": "^8.0.0",
-    "jest": "^29.0.0",
-    "@jest/globals": "^29.0.0",
     "@commitlint/cli": "^17.0.0",
-    "@commitlint/config-conventional": "^17.0.0"
+    "@commitlint/config-conventional": "^17.0.0",
+    "@jest/globals": "^29.0.0",
+    "eslint": "^8.0.0",
+    "husky": "^9.1.7",
+    "jest": "^29.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- document pre-commit workflow and project board usage
- ensure pipeline operator and do expression are covered in spec
- add husky pre-commit hook
- sync TODOs with project board via new workflow

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853694e60e08331b2b5affe10b615d2