### PR TITLE
Add workflow helper scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ This repository is optimized for iterative development by Codex agents.
    npm run lint && npm test -- --coverage
    ```
    Ensure test coverage stays above 90%.
+   You can also run all workflow checks and board syncing with:
+   ```bash
+   npm run workflow
+   ```
 
 ## Commit Guidelines
 - Use [Conventional Commits](https://www.conventionalcommits.org) (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ See `QUICK_START.md` for setup and development guidelines.
 Run `npm install` once to set up Husky hooks. Commits will automatically run
 `npm run lint` and `npm test` before being created.
 
+### Workflow Helper
+Use the convenience script to sync the project board, run linting, tests, and benchmarks in one go:
+
+```bash
+npm run workflow
+```
+
 ## Project Board
 
 Track progress and self-assign tasks on the [GitHub Project Board](https://github.com/your-org/experimental-js-lexer/projects/1).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "prepare": "node scripts/prepare-husky.cjs",
     "build:extension": "npm --prefix extension install && npm --prefix extension run build",
     "publish:extension": "npm --prefix extension install && npm --prefix extension run publish",
-    "sync:project": "node .github/scripts/setup-project-board.js && node .github/scripts/seed-todo.js"
+    "sync:project": "node .github/scripts/setup-project-board.js && node .github/scripts/seed-todo.js",
+    "workflow": "bash scripts/run-workflow.sh",
+    "next-task": "node scripts/next-task.cjs"
   },
   "keywords": [
     "lexer",

--- a/scripts/next-task.cjs
+++ b/scripts/next-task.cjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// scripts/next-task.cjs
+// Print the highest priority unchecked task from docs/TODO_CHECKLIST.md
+import fs from 'fs';
+import path from 'path';
+
+const checklistPath = path.join('docs', 'TODO_CHECKLIST.md');
+const content = fs.readFileSync(checklistPath, 'utf8');
+const match = content.match(/^- \[ \] (.+)$/m);
+if (match) {
+  console.log(match[1]);
+} else {
+  console.log('All tasks completed');
+}

--- a/scripts/run-workflow.sh
+++ b/scripts/run-workflow.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1. Ensure correct Node version and install deps
+node -v     # confirm Node >=18
+npm install
+
+# 2. Sync project board and seed issues (optional setup)
+npm run sync:project
+
+# 3. Lint, test with coverage, and benchmark
+npm run lint
+npm test -- --coverage
+npm run bench
+
+# 4. Display coverage summary
+grep -A1 "All files" coverage/lcov-report/index.html || true
+
+echo "Workflow checks complete."


### PR DESCRIPTION
## Summary
- add `workflow` and `next-task` npm scripts
- document workflow helper in README and AGENTS docs
- add bash script to run common workflow steps
- add Node script to output the highest priority task

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `npm run bench`


------
https://chatgpt.com/codex/tasks/task_e_68536c2f7b608331aa17fef6b02164c8