### PR TITLE
Add PipelineOperatorReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -124,5 +124,13 @@ Plugins may provide readers for any mode using a `modes` map and an optional
 ## 13. Pipeline Operator <a name="pipeline"></a>
 The experimental lexer will recognize the pipeline operator `|>` as a distinct `PIPELINE_OPERATOR` token. This reader should emit the token when the `|>` sequence is encountered in default mode. Future versions may support additional pipeline styles.
 
+Example tokenization:
+
+```
+a |> b
+```
+
+produces the tokens `[IDENTIFIER("a"), PIPELINE_OPERATOR("|>"), IDENTIFIER("b")]`.
+
 ## 14. Do Expressions <a name="do-expressions"></a>
 Do expressions allow block scoped evaluation returning the last statement value. The lexer must produce `DO_BLOCK_START` and `DO_BLOCK_END` tokens around the `do { ... }` body and handle nesting via the state stack.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -27,10 +27,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document how to build and register plugins.
 
 ## 21. Pipeline Operator
-- [ ] Define `PIPELINE_OPERATOR` token type.
-- [ ] Implement `PipelineOperatorReader` to emit this token.
-- [ ] Add unit tests ensuring `a |> b` tokenizes correctly.
-- [ ] Document new syntax in `docs/LEXER_SPEC.md`.
+ - [x] Define `PIPELINE_OPERATOR` token type.
+ - [x] Implement `PipelineOperatorReader` to emit this token.
+ - [x] Add unit tests ensuring `a |> b` tokenizes correctly.
+ - [x] Document new syntax in `docs/LEXER_SPEC.md`.
 
 ## 22. Do Expressions
 - [ ] Add `DoExpressionReader` for `do { ... }` blocks.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -13,7 +13,7 @@
 
 ### New Feature & Optimization Tasks
 
-- [ ] Implement PipelineOperatorReader for `|>` expressions
+ - [x] Implement PipelineOperatorReader for `|>` expressions
 - [ ] Implement DoExpressionReader to support `do { }` syntax
 - [ ] Add TypeScriptPlugin providing decorators and type annotations
 - [ ] Benchmark lexer speed and optimize CharStream caching

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -8,6 +8,7 @@ import { ExponentReader } from './ExponentReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
+import { PipelineOperatorReader } from './PipelineOperatorReader.js';
 import { OperatorReader } from './OperatorReader.js';
 import { PunctuationReader } from './PunctuationReader.js';
 import { TemplateStringReader } from './TemplateStringReader.js';
@@ -58,6 +59,7 @@ export class LexerEngine {
         NumberReader,
         StringReader,
         RegexOrDivideReader,
+        PipelineOperatorReader,
         OperatorReader,
         PunctuationReader,
         TemplateStringReader,

--- a/src/lexer/PipelineOperatorReader.js
+++ b/src/lexer/PipelineOperatorReader.js
@@ -1,0 +1,10 @@
+export function PipelineOperatorReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() === '|' && stream.peek() === '>') {
+    stream.advance();
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('PIPELINE_OPERATOR', '|>', startPos, endPos);
+  }
+  return null;
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -125,3 +125,12 @@ test("integration: shebang comment", () => {
   expect(toks[0].type).toBe("COMMENT");
   expect(toks[0].value).toBe("#!/usr/bin/env node");
 });
+
+test("integration: pipeline operator", () => {
+  const toks = tokenize("a |> b");
+  expect(toks.map(t => t.type)).toEqual([
+    "IDENTIFIER",
+    "PIPELINE_OPERATOR",
+    "IDENTIFIER"
+  ]);
+});

--- a/tests/readers/OperatorReader.test.js
+++ b/tests/readers/OperatorReader.test.js
@@ -9,7 +9,7 @@ test("OperatorReader reads single and multi-char", () => {
 });
 
 test("OperatorReader reads new ECMAScript operators", () => {
-  const stream = new CharStream("?. ?? ??= &&= ||= |>");
+  const stream = new CharStream("?. ?? ??= &&= ||=");
   let token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
   expect(token.value).toBe("?.");
   stream.advance();
@@ -24,7 +24,4 @@ test("OperatorReader reads new ECMAScript operators", () => {
   stream.advance();
   token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
   expect(token.value).toBe("||=");
-  stream.advance();
-  token = OperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
-  expect(token.value).toBe("|>");
 });

--- a/tests/readers/PipelineOperatorReader.test.js
+++ b/tests/readers/PipelineOperatorReader.test.js
@@ -1,0 +1,18 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { PipelineOperatorReader } from "../../src/lexer/PipelineOperatorReader.js";
+
+ test("PipelineOperatorReader reads |> operator", () => {
+   const stream = new CharStream("|>");
+   const tok = PipelineOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok.type).toBe("PIPELINE_OPERATOR");
+   expect(tok.value).toBe("|>");
+ });
+
+ test("PipelineOperatorReader returns null when sequence not matched", () => {
+   const stream = new CharStream("=>");
+   const pos = stream.getPosition();
+   const tok = PipelineOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok).toBeNull();
+   expect(stream.getPosition()).toEqual(pos);
+ });


### PR DESCRIPTION
## Summary
- define PipelineOperatorReader and integrate into engine
- add tests for the new reader and adjust operator tests
- document pipeline tokens in lexer spec
- mark checklist items complete

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68536e7966e883318ad8afa7f1290b1f