### PR TITLE
Add DoExpressionReader implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Project scaffold for experimental-js-lexer
 - Spec, tests, CI, lint, promptMap, issue templates
+- Do expression support via `DoExpressionReader`
 
 ### Changed
 - N/A

--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -134,3 +134,15 @@ produces the tokens `[IDENTIFIER("a"), PIPELINE_OPERATOR("|>"), IDENTIFIER("b")]
 
 ## 14. Do Expressions <a name="do-expressions"></a>
 Do expressions allow block scoped evaluation returning the last statement value. The lexer must produce `DO_BLOCK_START` and `DO_BLOCK_END` tokens around the `do { ... }` body and handle nesting via the state stack.
+
+Example:
+
+```
+do { do { 1 } }
+```
+
+results in the tokens:
+
+```
+[DO_BLOCK_START("do {"), DO_BLOCK_START("do {"), NUMBER("1"), DO_BLOCK_END("}"), DO_BLOCK_END("}")]
+```

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -33,10 +33,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
  - [x] Document new syntax in `docs/LEXER_SPEC.md`.
 
 ## 22. Do Expressions
-- [ ] Add `DoExpressionReader` for `do { ... }` blocks.
-- [ ] Handle nested `do` blocks with the state stack.
-- [ ] Test token sequence for simple examples.
-- [ ] Document behavior and edge cases.
+- [x] Add `DoExpressionReader` for `do { ... }` blocks.
+- [x] Handle nested `do` blocks with the state stack.
+- [x] Test token sequence for simple examples.
+- [x] Document behavior and edge cases.
 
 ## 23. TypeScript Plugin
 - [ ] Create `TypeScriptPlugin` under `src/plugins/typescript`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -14,7 +14,7 @@
 ### New Feature & Optimization Tasks
 
  - [x] Implement PipelineOperatorReader for `|>` expressions
-- [ ] Implement DoExpressionReader to support `do { }` syntax
+ - [x] Implement DoExpressionReader to support `do { }` syntax
 - [ ] Add TypeScriptPlugin providing decorators and type annotations
 - [ ] Benchmark lexer speed and optimize CharStream caching
 - [ ] Document incremental lexer state persistence

--- a/src/lexer/DoExpressionReader.js
+++ b/src/lexer/DoExpressionReader.js
@@ -1,0 +1,40 @@
+export function DoExpressionReader(stream, factory, engine) {
+  const startPos = stream.getPosition();
+
+  // Handle closing brace when inside a do block
+  if (engine && engine.currentMode && engine.currentMode() === 'do_block') {
+    if (stream.current() === '}') {
+      stream.advance();
+      const endPos = stream.getPosition();
+      if (engine.popMode) engine.popMode();
+      return factory('DO_BLOCK_END', '}', startPos, endPos);
+    }
+  }
+
+  // Detect "do {" to start a block
+  if (stream.current() === 'd' && stream.peek() === 'o') {
+    let offset = 2;
+    const after = stream.peek(offset);
+    if (after === null) return null;
+    if (/\s/.test(after) || after === '{') {
+      // look ahead through whitespace
+      while (/\s/.test(stream.peek(offset))) offset++;
+      if (stream.peek(offset) === '{') {
+        let value = 'do';
+        stream.advance();
+        stream.advance();
+        while (/\s/.test(stream.current())) {
+          value += stream.current();
+          stream.advance();
+        }
+        value += '{';
+        stream.advance();
+        const endPos = stream.getPosition();
+        if (engine && engine.pushMode) engine.pushMode('do_block');
+        return factory('DO_BLOCK_START', value, startPos, endPos);
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -9,6 +9,7 @@ import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
 import { PipelineOperatorReader } from './PipelineOperatorReader.js';
+import { DoExpressionReader } from './DoExpressionReader.js';
 import { OperatorReader } from './OperatorReader.js';
 import { PunctuationReader } from './PunctuationReader.js';
 import { TemplateStringReader } from './TemplateStringReader.js';
@@ -42,29 +43,32 @@ export class LexerEngine {
     this.buffer = [];
 
     // Mapping of mode -> reader list. Order determines priority.
+    const baseReaders = [
+      CommentReader,
+      WhitespaceReader,
+      ShebangReader,
+      DoExpressionReader,
+      IdentifierReader,
+      UnicodeIdentifierReader,
+      UnicodeEscapeIdentifierReader,
+      HexReader,
+      BinaryReader,
+      OctalReader,
+      BigIntReader,
+      NumericSeparatorReader,
+      ExponentReader,
+      NumberReader,
+      StringReader,
+      RegexOrDivideReader,
+      PipelineOperatorReader,
+      OperatorReader,
+      PunctuationReader,
+      TemplateStringReader,
+      JSXReader
+    ];
     this.modes = {
-      default: [
-        CommentReader,
-        WhitespaceReader,
-        ShebangReader,
-        IdentifierReader,
-        UnicodeIdentifierReader,
-        UnicodeEscapeIdentifierReader,
-        HexReader,
-        BinaryReader,
-        OctalReader,
-        BigIntReader,
-        NumericSeparatorReader,
-        ExponentReader,
-        NumberReader,
-        StringReader,
-        RegexOrDivideReader,
-        PipelineOperatorReader,
-        OperatorReader,
-        PunctuationReader,
-        TemplateStringReader,
-        JSXReader
-      ],
+      default: baseReaders,
+      do_block: [...baseReaders],
       template_string: [TemplateStringReader],
       regex: [RegexOrDivideReader],
       jsx: [JSXReader]

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -134,3 +134,14 @@ test("integration: pipeline operator", () => {
     "IDENTIFIER"
   ]);
 });
+
+test("integration: do expressions", () => {
+  const toks = tokenize("do { do { 1 } }");
+  expect(toks.map(t => t.type)).toEqual([
+    "DO_BLOCK_START",
+    "DO_BLOCK_START",
+    "NUMBER",
+    "DO_BLOCK_END",
+    "DO_BLOCK_END"
+  ]);
+});

--- a/tests/readers/DoExpressionReader.test.js
+++ b/tests/readers/DoExpressionReader.test.js
@@ -1,0 +1,33 @@
+import { jest } from "@jest/globals";
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { DoExpressionReader } from "../../src/lexer/DoExpressionReader.js";
+
+const mk = (t,v,s,e) => new Token(t,v,s,e);
+
+test("DoExpressionReader reads do block start", () => {
+  const stream = new CharStream("do {");
+  const engine = { pushMode: jest.fn(), currentMode: () => "default" };
+  const tok = DoExpressionReader(stream, mk, engine);
+  expect(tok.type).toBe("DO_BLOCK_START");
+  expect(tok.value).toBe("do {");
+  expect(engine.pushMode).toHaveBeenCalledWith("do_block");
+});
+
+test("DoExpressionReader reads do block end", () => {
+  const stream = new CharStream("}");
+  const engine = { currentMode: () => "do_block", popMode: jest.fn() };
+  const tok = DoExpressionReader(stream, mk, engine);
+  expect(tok.type).toBe("DO_BLOCK_END");
+  expect(tok.value).toBe("}");
+  expect(engine.popMode).toHaveBeenCalled();
+});
+
+test("DoExpressionReader returns null when not matched", () => {
+  const stream = new CharStream("doSomething");
+  const engine = { currentMode: () => "default" };
+  const pos = stream.getPosition();
+  const tok = DoExpressionReader(stream, mk, engine);
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement DoExpressionReader for `do { }` blocks
- wire into LexerEngine with new `do_block` mode
- document do expression tokens in `LEXER_SPEC`
- add unit tests and integration test for do expressions
- check off do expression tasks
- note change in changelog

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68537162402c8331b73048e7a2c702cc