### PR TITLE
Add DoExpressionReader support

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -133,4 +133,14 @@ a |> b
 produces the tokens `[IDENTIFIER("a"), PIPELINE_OPERATOR("|>"), IDENTIFIER("b")]`.
 
 ## 14. Do Expressions <a name="do-expressions"></a>
-Do expressions allow block scoped evaluation returning the last statement value. The lexer must produce `DO_BLOCK_START` and `DO_BLOCK_END` tokens around the `do { ... }` body and handle nesting via the state stack.
+Do expressions allow block scoped evaluation returning the last statement value. When the lexer encounters the sequence `do {`, it emits a `DO_BLOCK_START` token and pushes a `do_block` mode onto the state stack. The closing `}` in this mode emits a `DO_BLOCK_END` token and pops the mode. Any nested `do { ... }` sequences are handled recursively using the same mechanism.
+
+Example:
+
+```
+do { 1 }
+```
+
+produces the token sequence `[DO_BLOCK_START("do {"), NUMBER("1"), DO_BLOCK_END("}")]`.
+
+If an opening `do {` is found without a matching closing brace before EOF, the lexer leaves the mode on the stack, allowing incremental lexing to resume when more input arrives.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -33,10 +33,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
  - [x] Document new syntax in `docs/LEXER_SPEC.md`.
 
 ## 22. Do Expressions
-- [ ] Add `DoExpressionReader` for `do { ... }` blocks.
-- [ ] Handle nested `do` blocks with the state stack.
-- [ ] Test token sequence for simple examples.
-- [ ] Document behavior and edge cases.
+- [x] Add `DoExpressionReader` for `do { ... }` blocks.
+- [x] Handle nested `do` blocks with the state stack.
+- [x] Test token sequence for simple examples.
+- [x] Document behavior and edge cases.
 
 ## 23. TypeScript Plugin
 - [ ] Create `TypeScriptPlugin` under `src/plugins/typescript`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -13,8 +13,8 @@
 
 ### New Feature & Optimization Tasks
 
- - [x] Implement PipelineOperatorReader for `|>` expressions
-- [ ] Implement DoExpressionReader to support `do { }` syntax
+- [x] Implement PipelineOperatorReader for `|>` expressions
+- [x] Implement DoExpressionReader to support `do { }` syntax
 - [ ] Add TypeScriptPlugin providing decorators and type annotations
 - [ ] Benchmark lexer speed and optimize CharStream caching
 - [ ] Document incremental lexer state persistence

--- a/src/lexer/DoExpressionReader.js
+++ b/src/lexer/DoExpressionReader.js
@@ -1,0 +1,37 @@
+export function DoExpressionReader(stream, factory, engine) {
+  const startPos = stream.getPosition();
+
+  const mode = engine.currentMode();
+
+  if (mode === 'do_block') {
+    if (stream.current() === '}') {
+      stream.advance();
+      const endPos = stream.getPosition();
+      engine.popMode();
+      return factory('DO_BLOCK_END', '}', startPos, endPos);
+    }
+    // check for nested do blocks within a do block
+  }
+
+  // Recognize "do {" at start of expression or statement
+  if (mode === 'default' || mode === 'do_block') {
+    if (stream.input.startsWith('do', stream.index)) {
+      const afterDo = stream.index + 2;
+      let idx = afterDo;
+      while (/\s/.test(stream.input[idx])) idx++;
+      if (stream.input[idx] === '{') {
+        // consume 'do'
+        stream.advance();
+        stream.advance();
+        while (/\s/.test(stream.current())) stream.advance();
+        // consume '{'
+        stream.advance();
+        const endPos = stream.getPosition();
+        engine.pushMode('do_block');
+        return factory('DO_BLOCK_START', 'do {', startPos, endPos);
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -18,6 +18,7 @@ import { WhitespaceReader } from './WhitespaceReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
+import { DoExpressionReader } from './DoExpressionReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -47,6 +48,7 @@ export class LexerEngine {
         CommentReader,
         WhitespaceReader,
         ShebangReader,
+        DoExpressionReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -69,6 +71,7 @@ export class LexerEngine {
       regex: [RegexOrDivideReader],
       jsx: [JSXReader]
     };
+    this.modes.do_block = this.modes.default;
 
     // Apply registered plugins
     for (const plugin of LexerEngine.plugins) {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -134,3 +134,13 @@ test("integration: pipeline operator", () => {
     "IDENTIFIER"
   ]);
 });
+
+test("integration: do expression", () => {
+  const toks = tokenize("do { 1 }");
+  expect(toks.map(t => t.type)).toEqual([
+    "DO_BLOCK_START",
+    "NUMBER",
+    "DO_BLOCK_END"
+  ]);
+});
+

--- a/tests/readers/DoExpressionReader.test.js
+++ b/tests/readers/DoExpressionReader.test.js
@@ -1,0 +1,32 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { DoExpressionReader } from "../../src/lexer/DoExpressionReader.js";
+
+test("DoExpressionReader reads block start", () => {
+  const stream = new CharStream("do {");
+  let pushed = null;
+  const engine = { currentMode: () => 'default', pushMode: m => { pushed = m; }, popMode: () => {} };
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("DO_BLOCK_START");
+  expect(tok.value).toBe("do {");
+  expect(pushed).toBe('do_block');
+});
+
+test("DoExpressionReader reads block end", () => {
+  const stream = new CharStream("}");
+  let popped = false;
+  const engine = { currentMode: () => 'do_block', pushMode: () => {}, popMode: () => { popped = true; } };
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("DO_BLOCK_END");
+  expect(tok.value).toBe("}");
+  expect(popped).toBe(true);
+});
+
+test("DoExpressionReader returns null when not matching", () => {
+  const stream = new CharStream("do");
+  const engine = { currentMode: () => 'default', pushMode: () => {}, popMode: () => {} };
+  const pos = stream.getPosition();
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- add `DoExpressionReader` to recognize `do {` blocks
- wire reader in `LexerEngine`
- document do-expression behavior
- test `DoExpressionReader` and add integration coverage
- check off the todo list

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853719992d88331a3e65ffdb394238a