### PR TITLE
Implement DoExpressionReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -133,4 +133,12 @@ a |> b
 produces the tokens `[IDENTIFIER("a"), PIPELINE_OPERATOR("|>"), IDENTIFIER("b")]`.
 
 ## 14. Do Expressions <a name="do-expressions"></a>
-Do expressions allow block scoped evaluation returning the last statement value. The lexer must produce `DO_BLOCK_START` and `DO_BLOCK_END` tokens around the `do { ... }` body and handle nesting via the state stack.
+Do expressions allow block scoped evaluation returning the last statement value. When the lexer encounters the keyword `do` followed by an opening brace, it emits a `DO_BLOCK_START` token and pushes a `do_block` mode on the state stack. The body of the block is tokenized normally. Each closing brace decrements an internal counter and when the matching brace is reached a `DO_BLOCK_END` token is emitted and the mode is popped. Nested `do` blocks are therefore handled correctly.
+
+Example:
+
+```
+do { 1 + 2 }
+```
+
+produces the tokens `[DO_BLOCK_START("do {"), NUMBER("1"), OPERATOR("+"), NUMBER("2"), DO_BLOCK_END("}")]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -33,10 +33,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
  - [x] Document new syntax in `docs/LEXER_SPEC.md`.
 
 ## 22. Do Expressions
-- [ ] Add `DoExpressionReader` for `do { ... }` blocks.
-- [ ] Handle nested `do` blocks with the state stack.
-- [ ] Test token sequence for simple examples.
-- [ ] Document behavior and edge cases.
+- [x] Add `DoExpressionReader` for `do { ... }` blocks.
+- [x] Handle nested `do` blocks with the state stack.
+- [x] Test token sequence for simple examples.
+- [x] Document behavior and edge cases.
 
 ## 23. TypeScript Plugin
 - [ ] Create `TypeScriptPlugin` under `src/plugins/typescript`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -13,8 +13,8 @@
 
 ### New Feature & Optimization Tasks
 
- - [x] Implement PipelineOperatorReader for `|>` expressions
-- [ ] Implement DoExpressionReader to support `do { }` syntax
+- [x] Implement PipelineOperatorReader for `|>` expressions
+- [x] Implement DoExpressionReader to support `do { }` syntax
 - [ ] Add TypeScriptPlugin providing decorators and type annotations
 - [ ] Benchmark lexer speed and optimize CharStream caching
 - [ ] Document incremental lexer state persistence

--- a/src/lexer/DoExpressionReader.js
+++ b/src/lexer/DoExpressionReader.js
@@ -1,0 +1,38 @@
+export function DoExpressionReader(stream, factory, engine) {
+  const startPos = stream.getPosition();
+  if (engine && engine.currentMode && engine.currentMode() === 'do_block') {
+    if (stream.current() === '{') {
+      engine.doBlockDepth = (engine.doBlockDepth || 0) + 1;
+      return null; // regular brace within do block
+    }
+    if (stream.current() === '}') {
+      if (engine.doBlockDepth > 0) {
+        engine.doBlockDepth--;
+        return null;
+      }
+      stream.advance();
+      const endPos = stream.getPosition();
+      engine.popMode();
+      return factory('DO_BLOCK_END', '}', startPos, endPos);
+    }
+  }
+
+  if (stream.current() !== 'd' || stream.peek() !== 'o') return null;
+  const savedPos = stream.getPosition();
+  stream.advance();
+  stream.advance();
+  let ch = stream.current();
+  while (ch && /\s/.test(ch)) {
+    stream.advance();
+    ch = stream.current();
+  }
+  if (ch === '{') {
+    stream.advance();
+    engine && engine.pushMode && engine.pushMode('do_block');
+    engine.doBlockDepth = 0;
+    const endPos = stream.getPosition();
+    return factory('DO_BLOCK_START', 'do {', startPos, endPos);
+  }
+  stream.setPosition(savedPos);
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -18,6 +18,7 @@ import { WhitespaceReader } from './WhitespaceReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
+import { DoExpressionReader } from './DoExpressionReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -47,6 +48,30 @@ export class LexerEngine {
         CommentReader,
         WhitespaceReader,
         ShebangReader,
+        DoExpressionReader,
+        IdentifierReader,
+        UnicodeIdentifierReader,
+        UnicodeEscapeIdentifierReader,
+        HexReader,
+        BinaryReader,
+        OctalReader,
+        BigIntReader,
+        NumericSeparatorReader,
+        ExponentReader,
+        NumberReader,
+        StringReader,
+        RegexOrDivideReader,
+        PipelineOperatorReader,
+        OperatorReader,
+        PunctuationReader,
+        TemplateStringReader,
+        JSXReader
+      ],
+      do_block: [
+        CommentReader,
+        WhitespaceReader,
+        ShebangReader,
+        DoExpressionReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,

--- a/tests/readers/DoExpressionReader.test.js
+++ b/tests/readers/DoExpressionReader.test.js
@@ -1,0 +1,54 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { DoExpressionReader } from "../../src/lexer/DoExpressionReader.js";
+
+const dummyEngine = {
+  stateStack: ['default'],
+  pushMode(mode) { this.stateStack.push(mode); },
+  popMode() { this.stateStack.pop(); },
+  currentMode() { return this.stateStack[this.stateStack.length - 1]; }
+};
+
+test("DoExpressionReader reads do block start", () => {
+  const stream = new CharStream("do { x }");
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), dummyEngine);
+  expect(tok.type).toBe("DO_BLOCK_START");
+  expect(tok.value).toBe("do {");
+  expect(dummyEngine.currentMode()).toBe("do_block");
+});
+
+test("DoExpressionReader handles whitespace before brace", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("do   {\n}");
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("DO_BLOCK_START");
+  expect(engine.currentMode()).toBe("do_block");
+});
+
+test("DoExpressionReader emits end token at closing brace", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("do { }");
+  const startTok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(startTok.type).toBe("DO_BLOCK_START");
+  stream.advance();
+  const tok = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("DO_BLOCK_END");
+  expect(engine.currentMode()).toBe("default");
+});
+
+test("DoExpressionReader tracks nested blocks", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("do { do { } }");
+  const first = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(first.type).toBe("DO_BLOCK_START");
+  stream.advance();
+  const nested = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(nested.type).toBe("DO_BLOCK_START");
+  stream.advance();
+  const endNested = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(endNested.type).toBe("DO_BLOCK_END");
+  stream.advance();
+  const endOuter = DoExpressionReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(endOuter.type).toBe("DO_BLOCK_END");
+  expect(engine.currentMode()).toBe("default");
+});


### PR DESCRIPTION
## Summary
- implement `DoExpressionReader` and integrate it into the lexer
- support nested `do {}` blocks via a `do_block` mode
- document the behavior in `LEXER_SPEC.md`
- check off tasks in TODO lists
- add unit tests covering do block lexing

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853ac1ef6088331adc776d45a581ff5