### PR TITLE
Fix project board setup scripts

### DIFF
--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 import { Octokit } from '@octokit/rest';
 
-const token = process.env.GITHUB_TOKEN_WORKFLOW;
-const repoFull = process.env.GITHUB_TOKEN_REPO;
+const token = process.env.GITHUB_TOKEN;
+const repoFull = process.env.GITHUB_REPOSITORY;
 const boardName = process.env.PROJECT_NAME || 'Experimental Lexer';
 const columns = ['Todo', 'In Progress', 'Review', 'Done'];
 
 if (!token || !repoFull) {
-  console.error('GITHUB_TOKEN_WORKFLOW and GITHUB_TOKEN_REPO env vars required');
+  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY env vars required');
   process.exit(1);
 }
 
@@ -15,20 +15,36 @@ const [owner, repo] = repoFull.split('/');
 const octokit = new Octokit({ auth: token });
 
 async function ensureBoard() {
-  const { data: projects } = await octokit.rest.projects.listForRepo({ owner, repo });
+  const { data: projects } = await octokit.request('GET /repos/{owner}/{repo}/projects', {
+    owner,
+    repo,
+    mediaType: { previews: ['inertia'] }
+  });
   let project = projects.find(p => p.name === boardName);
   if (!project) {
-    project = (await octokit.rest.projects.createForRepo({ owner, repo, name: boardName })).data;
+    project = (await octokit.request('POST /repos/{owner}/{repo}/projects', {
+      owner,
+      repo,
+      name: boardName,
+      mediaType: { previews: ['inertia'] }
+    })).data;
     console.log(`Created board: ${boardName}`);
   } else {
     console.log(`Board exists: ${boardName}`);
   }
 
-  const { data: existingCols } = await octokit.rest.projects.listColumns({ project_id: project.id });
+  const { data: existingCols } = await octokit.request('GET /projects/{project_id}/columns', {
+    project_id: project.id,
+    mediaType: { previews: ['inertia'] }
+  });
   const names = existingCols.map(c => c.name);
   for (const name of columns) {
     if (!names.includes(name)) {
-      await octokit.rest.projects.createColumn({ project_id: project.id, name });
+      await octokit.request('POST /projects/{project_id}/columns', {
+        project_id: project.id,
+        name,
+        mediaType: { previews: ['inertia'] }
+      });
       console.log(`Added column ${name}`);
     }
   }


### PR DESCRIPTION
## Summary
- update GitHub project board scripts to work with Octokit v22
- use `octokit.request` calls with `inertia` preview headers
- require `GITHUB_TOKEN` and `GITHUB_REPOSITORY` env vars

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853b0103cbc8331b8736f211b36b845