### PR TITLE
Add TypeScript plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ registerPlugin(MyPlugin);
 console.log(tokenize('#')); // tokens include MY custom types
 ```
 
+The repository includes a `TypeScriptPlugin` that adds basic support for
+decorators, type annotations and generic parameters:
+
+```javascript
+import { TypeScriptPlugin } from './src/plugins/typescript/TypeScriptPlugin.js';
+registerPlugin(TypeScriptPlugin);
+```
+
 See `docs/PLUGIN_API.md` for details on authoring plugins.
 
 ## Auto-Merge Workflow

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -66,3 +66,15 @@ Register the plugin in the same way:
 ```javascript
 registerPlugin(TSDecoratorPlugin);
 ```
+
+## TypeScript Plugin
+
+The `TypeScriptPlugin` bundles readers for decorators, type annotations and
+generic parameters. When registered it disables automatic JSX detection so
+generics like `Map<string>` are tokenized correctly.
+
+```javascript
+import { TypeScriptPlugin } from './src/plugins/typescript/TypeScriptPlugin.js';
+
+registerPlugin(TypeScriptPlugin);
+```

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -15,6 +15,6 @@
 
 - [x] Implement PipelineOperatorReader for `|>` expressions
 - [x] Implement DoExpressionReader to support `do { }` syntax
-- [ ] Add TypeScriptPlugin providing decorators and type annotations
+- [x] Add TypeScriptPlugin providing decorators and type annotations
 - [ ] Benchmark lexer speed and optimize CharStream caching
 - [ ] Document incremental lexer state persistence

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -41,6 +41,7 @@ export class LexerEngine {
     this.stream = stream;
     this.stateStack = ['default'];
     this.buffer = [];
+    this.disableJsx = false;
 
     // Mapping of mode -> reader list. Order determines priority.
     this.modes = {
@@ -143,7 +144,7 @@ export class LexerEngine {
 
       // 1. Mode switching for JSX
       let mode = this.currentMode();
-      if (mode === 'default' && stream.current() === '<') {
+      if (mode === 'default' && !this.disableJsx && stream.current() === '<') {
         const next = stream.peek();
         if (/[A-Za-z/!?]|>/.test(next)) {
           this.pushMode('jsx');

--- a/src/plugins/typescript/TypeScriptPlugin.js
+++ b/src/plugins/typescript/TypeScriptPlugin.js
@@ -1,0 +1,71 @@
+export function TSDecoratorReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== '@') return null;
+  let value = '@';
+  stream.advance();
+  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+  return factory('DECORATOR', value, start, stream.getPosition());
+}
+
+export function TSTypeAnnotationReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== ':') return null;
+  let value = ':';
+  stream.advance();
+  // Consume whitespace after colon
+  while (stream.current() && /\s/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+  // Simple identifier or generic form
+  while (stream.current() && /[A-Za-z0-9_<>,\s]/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+    // stop at line break
+    if (/\n/.test(stream.current())) break;
+  }
+  return factory('TYPE_ANNOTATION', value.trimEnd(), start, stream.getPosition());
+}
+
+export function TSGenericParameterReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== '<') return null;
+  // Avoid JSX mode when TypeScript plugin is active
+  let value = '<';
+  stream.advance();
+  let depth = 1;
+  while (!stream.eof()) {
+    const ch = stream.current();
+    value += ch;
+    stream.advance();
+    if (ch === '<') depth++;
+    else if (ch === '>') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return factory('TYPE_PARAMETER', value, start, stream.getPosition());
+}
+
+export const TypeScriptPlugin = {
+  modes: {
+    default: [TSDecoratorReader, TSTypeAnnotationReader, TSGenericParameterReader]
+  },
+  init(engine) {
+    engine.disableJsx = true;
+    const orig = engine.modes.default.filter(r =>
+      r !== TSDecoratorReader &&
+      r !== TSTypeAnnotationReader &&
+      r !== TSGenericParameterReader
+    );
+    engine.modes.default = [
+      TSDecoratorReader,
+      TSTypeAnnotationReader,
+      TSGenericParameterReader,
+      ...orig
+    ];
+  }
+};

--- a/tests/typescriptPlugin.test.js
+++ b/tests/typescriptPlugin.test.js
@@ -1,0 +1,32 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { registerPlugin, clearPlugins } from '../index.js';
+import { TypeScriptPlugin } from '../src/plugins/typescript/TypeScriptPlugin.js';
+
+afterEach(() => {
+  clearPlugins();
+});
+
+test('TypeScriptPlugin reads decorators', () => {
+  registerPlugin(TypeScriptPlugin);
+  const engine = new LexerEngine(new CharStream('@Comp'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('DECORATOR');
+});
+
+test('TypeScriptPlugin reads type annotations', () => {
+  registerPlugin(TypeScriptPlugin);
+  const engine = new LexerEngine(new CharStream(': number'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('TYPE_ANNOTATION');
+  expect(tok.value).toBe(': number');
+});
+
+test('TypeScriptPlugin parses generic parameters without JSX', () => {
+  registerPlugin(TypeScriptPlugin);
+  const engine = new LexerEngine(new CharStream('Map<string>'));
+  const ident = engine.nextToken();
+  expect(ident.type).toBe('IDENTIFIER');
+  const generic = engine.nextToken();
+  expect(generic.type).toBe('TYPE_PARAMETER');
+});


### PR DESCRIPTION
## Summary
- add TypeScriptPlugin implementing decorator, type annotation and generic readers
- disable JSX detection when TypeScriptPlugin is active
- document the plugin usage
- mark TODO item complete
- test plugin behavior

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853b4d96d58833188dc92fbfada3a5c