### PR TITLE
fix(board): enforce env vars for board setup

### DIFF
--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -3,11 +3,11 @@ import { Octokit } from '@octokit/rest';
 
 const token = process.env.GITHUB_TOKEN;
 const repoFull = process.env.GITHUB_REPOSITORY;
-const boardName = process.env.PROJECT_NAME || 'Experimental Lexer';
+const boardName = process.env.PROJECT_NAME;
 const columns = ['Todo', 'In Progress', 'Review', 'Done'];
 
-if (!token || !repoFull) {
-  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY env vars required');
+if (!token || !repoFull || !boardName) {
+  console.error('GITHUB_TOKEN, GITHUB_REPOSITORY and PROJECT_NAME env vars required');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- require PROJECT_NAME along with repo and token
- drop fallback board name
- error on missing env vars

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm test -- --coverage`
- `GITHUB_TOKEN=xxx GITHUB_REPOSITORY=owner/repo PROJECT_NAME=Test node .github/scripts/setup-project-board.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853b6b657948331ba6e7912149da7a3