### PR TITLE
feat: add lexer state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ stream.on('data', tok => {
 
 See `docs/VS_CODE_EXAMPLE.md` for a more complete VS Code integration example.
 
+### Persisting Lexer State
+
+Both `IncrementalLexer` and `BufferedIncrementalLexer` support `saveState()` and
+`restoreState(state)` for resuming lexing without reprocessing the entire
+source.
+
+```javascript
+const lexer = new IncrementalLexer();
+lexer.feed('let x');
+const snapshot = lexer.saveState();
+
+const resumed = new IncrementalLexer();
+resumed.restoreState(snapshot);
+resumed.feed(' = 1;');
+```
+
 ## Plugin API
 
 Custom token readers can be installed at runtime. Register a plugin before

--- a/docs/INCREMENTAL_STATE.md
+++ b/docs/INCREMENTAL_STATE.md
@@ -1,0 +1,28 @@
+# Persisting Incremental Lexer State
+
+Both `IncrementalLexer` and `BufferedIncrementalLexer` can save their internal state so lexing can be resumed later. This is useful for editor sessions or long-running processes where re-tokenizing from the beginning would be wasteful.
+
+## Saving State
+
+Call `saveState()` on a lexer instance to obtain a serializable object:
+
+```javascript
+const lexer = new IncrementalLexer();
+lexer.feed('let x');
+const state = lexer.saveState();
+// persist `state` to disk or elsewhere
+```
+
+## Restoring State
+
+Create a new lexer and call `restoreState(state)` with a previously saved snapshot:
+
+```javascript
+const resumed = new IncrementalLexer();
+resumed.restoreState(state);
+resumed.feed(' = 1;');
+console.log(resumed.getTokens().map(t => t.type));
+// ['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'NUMBER', 'PUNCTUATION']
+```
+
+`BufferedIncrementalLexer` exposes the same API and will resume buffered tokens as expected.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -52,6 +52,6 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Update changelog with performance metrics.
 
 ## 25. Incremental Lexer Persistence
-- [ ] Document how to save and restore lexer state.
-- [ ] Provide example code snippet in `README.md`.
-- [ ] Add tests covering lexing resume functionality.
+- [x] Document how to save and restore lexer state.
+- [x] Provide example code snippet in `README.md`.
+- [x] Add tests covering lexing resume functionality.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -17,4 +17,4 @@
 - [x] Implement DoExpressionReader to support `do { }` syntax
 - [x] Add TypeScriptPlugin providing decorators and type annotations
 - [x] Benchmark lexer speed and optimize CharStream caching
-- [ ] Document incremental lexer state persistence
+- [x] Document incremental lexer state persistence

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -1,6 +1,7 @@
 import { CharStream } from '../lexer/CharStream.js';
 import { LexerEngine } from '../lexer/LexerEngine.js';
 import { LexerError } from '../lexer/LexerError.js';
+import { Token } from '../lexer/Token.js';
 
 /**
  * BufferedIncrementalLexer buffers incomplete tokens across feed() calls.
@@ -66,5 +67,53 @@ export class BufferedIncrementalLexer {
    */
   getTokens() {
     return this.tokens.slice();
+  }
+
+  /**
+   * Serialize lexer state for later restoration.
+   * @returns {object}
+   */
+  saveState() {
+    return {
+      input: this.stream.input,
+      position: this.stream.getPosition(),
+      tokens: this.tokens.map(t => t.toJSON()),
+      trivia: this.trivia.map(t => t.toJSON()),
+      engine: {
+        stateStack: [...this.engine.stateStack],
+        buffer: this.engine.buffer.map(t => t.toJSON()),
+        disableJsx: this.engine.disableJsx,
+        lastToken: this.engine.lastToken ? this.engine.lastToken.toJSON() : null
+      }
+    };
+  }
+
+  /**
+   * Restore a previously saved lexer state.
+   * @param {object} state
+   */
+  restoreState(state) {
+    this.stream = new CharStream(state.input);
+    this.stream.setPosition(state.position);
+    this.engine = new LexerEngine(this.stream);
+    this.engine.stateStack = [...state.engine.stateStack];
+    this.engine.buffer = state.engine.buffer.map(
+      t => new Token(t.type, t.value, t.start, t.end)
+    );
+    this.engine.disableJsx = state.engine.disableJsx;
+    this.engine.lastToken = state.engine.lastToken
+      ? new Token(
+          state.engine.lastToken.type,
+          state.engine.lastToken.value,
+          state.engine.lastToken.start,
+          state.engine.lastToken.end
+        )
+      : null;
+    this.tokens = state.tokens.map(
+      t => new Token(t.type, t.value, t.start, t.end)
+    );
+    this.trivia = state.trivia.map(
+      t => new Token(t.type, t.value, t.start, t.end)
+    );
   }
 }

--- a/src/integration/IncrementalLexer.js
+++ b/src/integration/IncrementalLexer.js
@@ -1,5 +1,6 @@
 import { CharStream } from '../lexer/CharStream.js';
 import { LexerEngine } from '../lexer/LexerEngine.js';
+import { Token } from '../lexer/Token.js';
 
 /**
  * IncrementalLexer allows feeding code chunks and emits tokens as they are produced.
@@ -43,5 +44,49 @@ export class IncrementalLexer {
    */
   getTokens() {
     return this.tokens.slice();
+  }
+
+  /**
+   * Serialize the lexer's internal state for persistence.
+   * @returns {object}
+   */
+  saveState() {
+    return {
+      input: this.stream.input,
+      position: this.stream.getPosition(),
+      tokens: this.tokens.map(t => t.toJSON()),
+      engine: {
+        stateStack: [...this.engine.stateStack],
+        buffer: this.engine.buffer.map(t => t.toJSON()),
+        disableJsx: this.engine.disableJsx,
+        lastToken: this.engine.lastToken ? this.engine.lastToken.toJSON() : null
+      }
+    };
+  }
+
+  /**
+   * Restore a previously saved lexer state.
+   * @param {object} state
+   */
+  restoreState(state) {
+    this.stream = new CharStream(state.input);
+    this.stream.setPosition(state.position);
+    this.engine = new LexerEngine(this.stream);
+    this.engine.stateStack = [...state.engine.stateStack];
+    this.engine.buffer = state.engine.buffer.map(
+      t => new Token(t.type, t.value, t.start, t.end)
+    );
+    this.engine.disableJsx = state.engine.disableJsx;
+    this.engine.lastToken = state.engine.lastToken
+      ? new Token(
+          state.engine.lastToken.type,
+          state.engine.lastToken.value,
+          state.engine.lastToken.start,
+          state.engine.lastToken.end
+        )
+      : null;
+    this.tokens = state.tokens.map(
+      t => new Token(t.type, t.value, t.start, t.end)
+    );
   }
 }

--- a/tests/BufferedIncrementalLexer.test.js
+++ b/tests/BufferedIncrementalLexer.test.js
@@ -52,3 +52,22 @@ test('buffers incomplete template string with expression across feeds', () => {
   lexer.feed('+2}`;');
   expect(types).toEqual(['KEYWORD', 'IDENTIFIER', 'OPERATOR', 'TEMPLATE_STRING', 'PUNCTUATION']);
 });
+
+test('saveState/restoreState resumes buffered lexing', () => {
+  const lexer = new BufferedIncrementalLexer();
+  lexer.feed('const s = "hel');
+  const state = lexer.saveState();
+
+  const resumed = new BufferedIncrementalLexer();
+  resumed.restoreState(state);
+  resumed.feed('lo";');
+
+  const types = resumed.getTokens().map(t => t.type);
+  expect(types).toEqual([
+    'KEYWORD',
+    'IDENTIFIER',
+    'OPERATOR',
+    'STRING',
+    'PUNCTUATION'
+  ]);
+});

--- a/tests/incremental.test.js
+++ b/tests/incremental.test.js
@@ -33,3 +33,22 @@ test('feeding whitespace only produces no tokens', () => {
   lexer.feed('   ');
   expect(lexer.getTokens()).toEqual([]);
 });
+
+test('saveState/restoreState resumes lexing', () => {
+  const lexer = new IncrementalLexer();
+  lexer.feed('let x');
+  const state = lexer.saveState();
+
+  const resumed = new IncrementalLexer();
+  resumed.restoreState(state);
+  resumed.feed(' = 1;');
+
+  const types = resumed.getTokens().map(t => t.type);
+  expect(types).toEqual([
+    'KEYWORD',
+    'IDENTIFIER',
+    'OPERATOR',
+    'NUMBER',
+    'PUNCTUATION'
+  ]);
+});


### PR DESCRIPTION
## Summary
- support saving and restoring state in IncrementalLexer and BufferedIncrementalLexer
- document persistence API
- show example in README
- mark checklist items as complete
- test state restoration logic

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853c233fa3c8331b0366a75ca330b6e