### PR TITLE
fix: default board name for project setup

### DIFF
--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -3,11 +3,11 @@ import { Octokit } from '@octokit/rest';
 
 const token = process.env.GITHUB_TOKEN;
 const repoFull = process.env.GITHUB_REPOSITORY;
-const boardName = process.env.PROJECT_NAME;
+const boardName = process.env.PROJECT_NAME || 'Experimental Lexer';
 const columns = ['Todo', 'In Progress', 'Review', 'Done'];
 
-if (!token || !repoFull || !boardName) {
-  console.error('GITHUB_TOKEN, GITHUB_REPOSITORY and PROJECT_NAME env vars required');
+if (!token || !repoFull) {
+  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY env vars required');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- use a default project board name when `PROJECT_NAME` is not supplied
- relax required env vars in `setup-project-board.js`

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853c9445f708331a4a758771aec79b3