### PR TITLE
Fix close-todo workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,5 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: npm install
+
       - name: Close completed TODOs
         run: node .github/scripts/close-todo.js


### PR DESCRIPTION
## Summary
- install node dependencies in auto-merge workflow before running close-todo script

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `GITHUB_TOKEN=foo GITHUB_REPOSITORY=owner/repo node .github/scripts/close-todo.js`

------
https://chatgpt.com/codex/tasks/task_e_6853d4547cf083318c1ffa701b3a0fa2