### PR TITLE
Add roadmap for lexical enhancements

### DIFF
--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -55,3 +55,21 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document how to save and restore lexer state.
 - [x] Provide example code snippet in `README.md`.
 - [x] Add tests covering lexing resume functionality.
+
+## 26. Private Identifiers
+- [ ] Add `PrivateIdentifierReader` for tokens like `#field`.
+- [ ] Insert the reader early in `LexerEngine`'s default mode.
+- [ ] Write unit tests covering class fields and methods.
+- [ ] Document new `PRIVATE_IDENTIFIER` token in `docs/LEXER_SPEC.md`.
+
+## 27. Regex Named Capture Groups
+- [ ] Extend `RegexOrDivideReader` to recognize `(?<name>...)` syntax.
+- [ ] Validate capture group names using identifier rules.
+- [ ] Add tests with single and multiple named groups.
+- [ ] Document named group parsing rules and limitations.
+
+## 28. Import Assertions
+- [ ] Implement `ImportAssertionReader` handling `assert { ... }` clauses.
+- [ ] Hook the reader into import parsing flows in `LexerEngine`.
+- [ ] Test static and dynamic import assertion examples.
+- [ ] Document the new syntax in usage docs.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -18,3 +18,9 @@
 - [x] Add TypeScriptPlugin providing decorators and type annotations
 - [x] Benchmark lexer speed and optimize CharStream caching
 - [x] Document incremental lexer state persistence
+
+### Future Lexical Enhancement Tasks
+
+- [ ] Implement PrivateIdentifierReader for `#private` fields
+- [ ] Support named capture groups in regular expressions
+- [ ] Recognize import assertion syntax after `import` statements


### PR DESCRIPTION
## Summary
- outline future lexical capability tasks in `docs/TODO_CHECKLIST.md`
- break down the new tasks in `docs/TASK_BREAKDOWN.md`

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853da1533508331afa5e8b624ab8281