### PR TITLE
Add PrivateIdentifierReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -142,3 +142,17 @@ do { 1 + 2 }
 ```
 
 produces the tokens `[DO_BLOCK_START("do {"), NUMBER("1"), OPERATOR("+"), NUMBER("2"), DO_BLOCK_END("}")]`.
+
+## 15. Private Identifiers <a name="private-identifiers"></a>
+Class elements starting with `#` are tokenized as `PRIVATE_IDENTIFIER`.
+The reader matches `#` followed by an identifier name consisting of
+letters, digits and underscores.
+
+Example:
+
+```
+class C { #x; }
+```
+
+yields tokens `[KEYWORD("class"), IDENTIFIER("C"), PUNCTUATION("{"),
+PRIVATE_IDENTIFIER("#x"), PUNCTUATION(";"), PUNCTUATION("}")]`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -21,6 +21,6 @@
 
 ### Future Lexical Enhancement Tasks
 
-- [ ] Implement PrivateIdentifierReader for `#private` fields
+- [x] Implement PrivateIdentifierReader for `#private` fields
 - [ ] Support named capture groups in regular expressions
 - [ ] Recognize import assertion syntax after `import` statements

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -19,6 +19,7 @@ import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
 import { DoExpressionReader } from './DoExpressionReader.js';
+import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -50,6 +51,7 @@ export class LexerEngine {
         WhitespaceReader,
         ShebangReader,
         DoExpressionReader,
+        PrivateIdentifierReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -73,6 +75,7 @@ export class LexerEngine {
         WhitespaceReader,
         ShebangReader,
         DoExpressionReader,
+        PrivateIdentifierReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,

--- a/src/lexer/PrivateIdentifierReader.js
+++ b/src/lexer/PrivateIdentifierReader.js
@@ -1,0 +1,32 @@
+export function PrivateIdentifierReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  stream.advance();
+  let ch = stream.current();
+  if (ch === null || !isIdentifierStart(ch)) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  let value = '#';
+  while (ch !== null && isIdentifierPart(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('PRIVATE_IDENTIFIER', value, startPos, endPos);
+}
+
+function isIdentifierStart(ch) {
+  return (
+    (ch >= 'A' && ch <= 'Z') ||
+    (ch >= 'a' && ch <= 'z') ||
+    ch === '_'
+  );
+}
+
+function isIdentifierPart(ch) {
+  return isIdentifierStart(ch) || (ch >= '0' && ch <= '9');
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -134,3 +134,10 @@ test("integration: pipeline operator", () => {
     "IDENTIFIER"
   ]);
 });
+
+test("integration: private class fields and methods", () => {
+  const src = "class C { #x; #m() {} }";
+  const toks = tokenize(src);
+  expect(toks.map(t => t.type)).toContain("PRIVATE_IDENTIFIER");
+  expect(toks.find(t => t.type === "PRIVATE_IDENTIFIER").value).toBe("#x");
+});

--- a/tests/readers/PrivateIdentifierReader.test.js
+++ b/tests/readers/PrivateIdentifierReader.test.js
@@ -1,0 +1,19 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { PrivateIdentifierReader } from "../../src/lexer/PrivateIdentifierReader.js";
+
+test("PrivateIdentifierReader reads private identifier", () => {
+  const stream = new CharStream("#foo bar");
+  const tok = PrivateIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("PRIVATE_IDENTIFIER");
+  expect(tok.value).toBe("#foo");
+  expect(stream.getPosition().index).toBe(4);
+});
+
+test("PrivateIdentifierReader returns null when not matched", () => {
+  const stream = new CharStream("#1");
+  const pos = stream.getPosition();
+  const tok = PrivateIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `PrivateIdentifierReader` for `#private` class fields
- integrate reader into `LexerEngine`
- mark TODO for private identifiers as done
- document `PRIVATE_IDENTIFIER` token
- test private identifiers

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853e3ee9eac83318fc0f58d86668dc1