### PR TITLE
Implement PrivateIdentifierReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -142,3 +142,21 @@ do { 1 + 2 }
 ```
 
 produces the tokens `[DO_BLOCK_START("do {"), NUMBER("1"), OPERATOR("+"), NUMBER("2"), DO_BLOCK_END("}")]`.
+
+## 15. Private Identifiers <a name="private-identifiers"></a>
+Private class fields and methods begin with a `#` prefix. When the lexer
+encounters `#` followed by an identifier, it emits a `PRIVATE_IDENTIFIER`
+token containing the full sequence including the hash.
+
+Example:
+
+```
+class C { #field; #method() {} }
+```
+
+produces the tokens `[
+  KEYWORD("class"), IDENTIFIER("C"), PUNCTUATION("{"),
+  PRIVATE_IDENTIFIER("#field"), PUNCTUATION(";"),
+  PRIVATE_IDENTIFIER("#method"), PUNCTUATION("("), PUNCTUATION(")"),
+  PUNCTUATION("{"), PUNCTUATION("}"), PUNCTUATION("}")
+]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -57,10 +57,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Add tests covering lexing resume functionality.
 
 ## 26. Private Identifiers
-- [ ] Add `PrivateIdentifierReader` for tokens like `#field`.
-- [ ] Insert the reader early in `LexerEngine`'s default mode.
-- [ ] Write unit tests covering class fields and methods.
-- [ ] Document new `PRIVATE_IDENTIFIER` token in `docs/LEXER_SPEC.md`.
+- [x] Add `PrivateIdentifierReader` for tokens like `#field`.
+- [x] Insert the reader early in `LexerEngine`'s default mode.
+- [x] Write unit tests covering class fields and methods.
+- [x] Document new `PRIVATE_IDENTIFIER` token in `docs/LEXER_SPEC.md`.
 
 ## 27. Regex Named Capture Groups
 - [ ] Extend `RegexOrDivideReader` to recognize `(?<name>...)` syntax.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -21,6 +21,6 @@
 
 ### Future Lexical Enhancement Tasks
 
-- [ ] Implement PrivateIdentifierReader for `#private` fields
+ - [x] Implement PrivateIdentifierReader for `#private` fields
 - [ ] Support named capture groups in regular expressions
 - [ ] Recognize import assertion syntax after `import` statements

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -19,6 +19,7 @@ import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
 import { DoExpressionReader } from './DoExpressionReader.js';
+import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -49,6 +50,7 @@ export class LexerEngine {
         CommentReader,
         WhitespaceReader,
         ShebangReader,
+        PrivateIdentifierReader,
         DoExpressionReader,
         IdentifierReader,
         UnicodeIdentifierReader,
@@ -72,6 +74,7 @@ export class LexerEngine {
         CommentReader,
         WhitespaceReader,
         ShebangReader,
+        PrivateIdentifierReader,
         DoExpressionReader,
         IdentifierReader,
         UnicodeIdentifierReader,

--- a/src/lexer/PrivateIdentifierReader.js
+++ b/src/lexer/PrivateIdentifierReader.js
@@ -1,0 +1,21 @@
+export function PrivateIdentifierReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  stream.advance();
+  let ch = stream.current();
+  if (ch === null || !(/[A-Za-z_]/.test(ch))) {
+    stream.setPosition(startPos);
+    return null;
+  }
+  let value = '#';
+  value += ch;
+  stream.advance();
+  ch = stream.current();
+  while (ch !== null && /[A-Za-z0-9_]/.test(ch)) {
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  const endPos = stream.getPosition();
+  return factory('PRIVATE_IDENTIFIER', value, startPos, endPos);
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -134,3 +134,21 @@ test("integration: pipeline operator", () => {
     "IDENTIFIER"
   ]);
 });
+
+test("integration: private identifiers", () => {
+  const toks = tokenize("class C { #a; #b() {} }");
+  expect(toks.map(t => t.type)).toEqual([
+    "KEYWORD",
+    "IDENTIFIER",
+    "PUNCTUATION",
+    "PRIVATE_IDENTIFIER",
+    "PUNCTUATION",
+    "PRIVATE_IDENTIFIER",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "PUNCTUATION"
+  ]);
+});
+

--- a/tests/readers/PrivateIdentifierReader.test.js
+++ b/tests/readers/PrivateIdentifierReader.test.js
@@ -1,0 +1,18 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { PrivateIdentifierReader } from "../../src/lexer/PrivateIdentifierReader.js";
+
+test("PrivateIdentifierReader reads #name", () => {
+  const stream = new CharStream("#name");
+  const tok = PrivateIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("PRIVATE_IDENTIFIER");
+  expect(tok.value).toBe("#name");
+});
+
+test("PrivateIdentifierReader returns null when invalid", () => {
+  const stream = new CharStream("# 1");
+  const pos = stream.getPosition();
+  const tok = PrivateIdentifierReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- support private identifiers `#field`
- add PrivateIdentifierReader to engine modes
- document `PRIVATE_IDENTIFIER` token
- test lexer support for private identifiers
- update TODO lists

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853e78bedd483318e83a4854007b606