### PR TITLE
Add new lexical capability tasks

### DIFF
--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -73,3 +73,15 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [ ] Hook the reader into import parsing flows in `LexerEngine`.
 - [ ] Test static and dynamic import assertion examples.
 - [ ] Document the new syntax in usage docs.
+
+## 29. Record and Tuple Syntax
+- [ ] Implement `RecordAndTupleReader` to tokenize `#{}` and `#[]` constructs.
+- [ ] Integrate the reader into default mode of `LexerEngine`.
+- [ ] Add unit tests for record and tuple literals.
+- [ ] Document record and tuple tokenization in `docs/LEXER_SPEC.md`.
+
+## 30. Unicode Property Escapes
+- [ ] Extend `RegexOrDivideReader` to support `\p{...}` and `\P{...}` escapes.
+- [ ] Validate property names using Unicode property data.
+- [ ] Provide tests covering positive and negative property escapes.
+- [ ] Document supported properties and limitations.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -21,6 +21,8 @@
 
 ### Future Lexical Enhancement Tasks
 
- - [x] Implement PrivateIdentifierReader for `#private` fields
+- [x] Implement PrivateIdentifierReader for `#private` fields
 - [ ] Support named capture groups in regular expressions
 - [ ] Recognize import assertion syntax after `import` statements
+- [ ] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
+- [ ] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions


### PR DESCRIPTION
## Summary
- add tasks to TODO checklist for further lexical enhancements
- break down new tasks in TASK_BREAKDOWN

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853e92a018c83319022d85469462ae9