### PR TITLE
Add new future lexical tasks

### DIFF
--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -85,3 +85,30 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [ ] Validate property names using Unicode property data.
 - [ ] Provide tests covering positive and negative property escapes.
 - [ ] Document supported properties and limitations.
+
+## 31. HTML Comment Support
+- [ ] Add `HTMLCommentReader` for `<!--` and `-->`.
+- [ ] Allow HTML-style comments at script boundaries.
+- [ ] Add unit tests for start and end comments.
+- [ ] Document in `docs/LEXER_SPEC.md`.
+
+## 32. Module Block Tokens
+- [ ] Create `ModuleBlockReader` for `module { }` syntax.
+- [ ] Support nested module blocks.
+- [ ] Add token type definitions and tests.
+- [ ] Document new tokens.
+
+## 33. Decimal Literal Reader
+- [ ] Implement `DecimalLiteralReader` for `123.45m` or `0d123.45`.
+- [ ] Add tokens and numeric tests.
+- [ ] Update documentation for decimal notation.
+
+## 34. Explicit Resource Management
+- [ ] Tokenize `using` and `await using` constructs.
+- [ ] Add tests covering top-level and nested usage.
+- [ ] Document behavior in `docs/LEXER_SPEC.md`.
+
+## 35. Pattern Matching Tokens
+- [ ] Add `match` and `case` tokens for future pattern matching.
+- [ ] Add tokenization tests.
+- [ ] Document reserved keywords.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -26,3 +26,8 @@
 - [ ] Recognize import assertion syntax after `import` statements
 - [ ] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
 - [ ] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
+- [ ] Implement HTML comment reader for `<!--` and `-->`
+- [ ] Add ModuleBlockReader for `module { ... }` blocks
+- [ ] Support decimal literals like `123.45m` or `0d123.45`
+- [ ] Tokenize `using` and `await using` statements
+- [ ] Add tokens for pattern matching `match`/`case` syntax


### PR DESCRIPTION
## Summary
- add more lexical enhancement tasks to TODO checklist
- expand TASK_BREAKDOWN with sections for HTML comments, module blocks, decimal literals, explicit resource management, and pattern matching

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853eec3f3048331a47622b51cb9ef7c