### PR TITLE
Add ImportAssertion reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -163,3 +163,21 @@ produces the tokens `[
   PRIVATE_IDENTIFIER("#method"), PUNCTUATION("("), PUNCTUATION(")"),
   PUNCTUATION("{"), PUNCTUATION("}"), PUNCTUATION("}")
 ]`.
+
+## 16. Import Assertions <a name="import-assertions"></a>
+Import statements may include an `assert` clause to provide metadata about the
+module being imported. The lexer recognizes the sequence `assert { ... }` (or
+`assert: { ... }` inside dynamic import options) as a single
+`IMPORT_ASSERTION` token containing the entire clause.
+
+Example:
+
+```
+import data from "./d.json" assert { type: "json" };
+```
+
+produces the tokens `[
+  KEYWORD("import"), IDENTIFIER("data"), IDENTIFIER("from"),
+  STRING("./d.json"), IMPORT_ASSERTION("assert { type: \"json\" }"),
+  PUNCTUATION(";")
+]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -69,10 +69,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [ ] Document named group parsing rules and limitations.
 
 ## 28. Import Assertions
-- [ ] Implement `ImportAssertionReader` handling `assert { ... }` clauses.
-- [ ] Hook the reader into import parsing flows in `LexerEngine`.
-- [ ] Test static and dynamic import assertion examples.
-- [ ] Document the new syntax in usage docs.
+ - [x] Implement `ImportAssertionReader` handling `assert { ... }` clauses.
+ - [x] Hook the reader into import parsing flows in `LexerEngine`.
+ - [x] Test static and dynamic import assertion examples.
+ - [x] Document the new syntax in usage docs.
 
 ## 29. Record and Tuple Syntax
 - [ ] Implement `RecordAndTupleReader` to tokenize `#{}` and `#[]` constructs.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -23,7 +23,7 @@
 
 - [x] Implement PrivateIdentifierReader for `#private` fields
 - [x] Support named capture groups in regular expressions
-- [ ] Recognize import assertion syntax after `import` statements
+- [x] Recognize import assertion syntax after `import` statements
 - [ ] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
 - [ ] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
 - [ ] Implement HTML comment reader for `<!--` and `-->`

--- a/src/lexer/ImportAssertionReader.js
+++ b/src/lexer/ImportAssertionReader.js
@@ -1,0 +1,82 @@
+export function ImportAssertionReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (!stream.input.startsWith('assert', stream.index)) return null;
+
+  // consume 'assert'
+  let value = '';
+  for (const ch of 'assert') {
+    if (stream.current() !== ch) {
+      stream.setPosition(startPos);
+      return null;
+    }
+    value += ch;
+    stream.advance();
+  }
+
+  // require whitespace or ':' or '{' to avoid matching longer identifiers
+  const next = stream.current();
+  if (next !== ':' && next !== '{' && !(/\s/.test(next))) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  // whitespace after 'assert'
+  while (!stream.eof() && /\s/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+
+  // optional ':'
+  if (stream.current() === ':') {
+    value += ':';
+    stream.advance();
+    while (!stream.eof() && /\s/.test(stream.current())) {
+      value += stream.current();
+      stream.advance();
+    }
+  }
+
+  if (stream.current() !== '{') {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  value += '{';
+  stream.advance();
+  let depth = 1;
+  let inString = null;
+  while (!stream.eof() && depth > 0) {
+    const ch = stream.current();
+    value += ch;
+    stream.advance();
+
+    if (inString) {
+      if (ch === '\\') {
+        if (!stream.eof()) {
+          value += stream.current();
+          stream.advance();
+        }
+        continue;
+      }
+      if (ch === inString) {
+        inString = null;
+      }
+      continue;
+    } else {
+      if (ch === '"' || ch === "'" || ch === '`') {
+        inString = ch;
+        continue;
+      }
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+  }
+
+  if (depth !== 0) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('IMPORT_ASSERTION', value, startPos, endPos);
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -20,6 +20,7 @@ import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.j
 import { ShebangReader } from './ShebangReader.js';
 import { DoExpressionReader } from './DoExpressionReader.js';
 import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
+import { ImportAssertionReader } from './ImportAssertionReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -52,6 +53,7 @@ export class LexerEngine {
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
+        ImportAssertionReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -76,6 +78,7 @@ export class LexerEngine {
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
+        ImportAssertionReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -152,3 +152,32 @@ test("integration: private identifiers", () => {
   ]);
 });
 
+test("integration: import assertions", () => {
+  const src = 'import data from "./d.json" assert { type: "json" };';
+  const toks = tokenize(src);
+  expect(toks.map(t => t.type)).toEqual([
+    "KEYWORD",
+    "IDENTIFIER",
+    "IDENTIFIER",
+    "STRING",
+    "IMPORT_ASSERTION",
+    "PUNCTUATION"
+  ]);
+});
+
+test("integration: dynamic import assertions", () => {
+  const src = 'import("./d.json", { assert: { type: "json" } });';
+  const toks = tokenize(src);
+  expect(toks.map(t => t.type)).toEqual([
+    "KEYWORD",
+    "PUNCTUATION",
+    "STRING",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "IMPORT_ASSERTION",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "PUNCTUATION"
+  ]);
+});
+

--- a/tests/readers/ImportAssertionReader.test.js
+++ b/tests/readers/ImportAssertionReader.test.js
@@ -1,0 +1,25 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ImportAssertionReader } from "../../src/lexer/ImportAssertionReader.js";
+
+test("ImportAssertionReader reads assert clause", () => {
+  const stream = new CharStream("assert { type: 'json' }");
+  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("IMPORT_ASSERTION");
+  expect(tok.value).toBe("assert { type: 'json' }");
+});
+
+test("ImportAssertionReader reads with colon syntax", () => {
+  const stream = new CharStream("assert: { type: 'json' }");
+  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("IMPORT_ASSERTION");
+  expect(tok.value).toBe("assert: { type: 'json' }");
+});
+
+test("ImportAssertionReader returns null for non-matching text", () => {
+  const stream = new CharStream("assert true");
+  const pos = stream.getPosition();
+  const tok = ImportAssertionReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `ImportAssertionReader`
- wire the reader into `LexerEngine`
- document import assertion tokens
- add unit and integration tests
- update TODO lists

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853f174ab688331ab7ba200dc3ec321