### PR TITLE
Implement Record and Tuple literal support

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -181,3 +181,22 @@ produces the tokens `[
   STRING("./d.json"), IMPORT_ASSERTION("assert { type: \"json\" }"),
   PUNCTUATION(";")
 ]`.
+
+## 17. Record and Tuple Literals <a name="record-tuple"></a>
+Record (`#{}`) and tuple (`#[ ]`) literals start with `#` followed by
+`{` or `[`.
+When these sequences are encountered, the lexer emits a `RECORD_START`
+or `TUPLE_START` token. The closing delimiters are the normal `}` and
+`]` punctuation tokens.
+
+Example:
+
+```
+#{ a: 1 }
+#[1]
+```
+
+produces the tokens `[
+  RECORD_START("#{"), IDENTIFIER("a"), NUMBER("1"), PUNCTUATION("}"),
+  TUPLE_START("#["), NUMBER("1"), PUNCTUATION("]")
+]`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -24,7 +24,7 @@
 - [x] Implement PrivateIdentifierReader for `#private` fields
 - [x] Support named capture groups in regular expressions
 - [x] Recognize import assertion syntax after `import` statements
-- [ ] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
+- [x] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
 - [ ] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
 - [ ] Implement HTML comment reader for `<!--` and `-->`
 - [ ] Add ModuleBlockReader for `module { ... }` blocks

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -21,6 +21,7 @@ import { ShebangReader } from './ShebangReader.js';
 import { DoExpressionReader } from './DoExpressionReader.js';
 import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { ImportAssertionReader } from './ImportAssertionReader.js';
+import { RecordAndTupleReader } from './RecordAndTupleReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -54,6 +55,7 @@ export class LexerEngine {
         PrivateIdentifierReader,
         DoExpressionReader,
         ImportAssertionReader,
+        RecordAndTupleReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -79,6 +81,7 @@ export class LexerEngine {
         PrivateIdentifierReader,
         DoExpressionReader,
         ImportAssertionReader,
+        RecordAndTupleReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,

--- a/src/lexer/RecordAndTupleReader.js
+++ b/src/lexer/RecordAndTupleReader.js
@@ -1,0 +1,14 @@
+export function RecordAndTupleReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '#') return null;
+  const next = stream.peek();
+  if (next !== '{' && next !== '[') return null;
+  // consume '#'
+  stream.advance();
+  // consume '{' or '['
+  stream.advance();
+  const endPos = stream.getPosition();
+  const type = next === '{' ? 'RECORD_START' : 'TUPLE_START';
+  const value = next === '{' ? '#{' : '#[';
+  return factory(type, value, startPos, endPos);
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -181,3 +181,16 @@ test("integration: dynamic import assertions", () => {
   ]);
 });
 
+test("integration: record and tuple literals", () => {
+  const toks = tokenize("#{a:1} #[1]");
+  expect(toks.map(t => t.type)).toEqual([
+    "RECORD_START",
+    "IDENTIFIER",
+    "NUMBER",
+    "PUNCTUATION",
+    "TUPLE_START",
+    "NUMBER",
+    "PUNCTUATION"
+  ]);
+});
+

--- a/tests/readers/RecordAndTupleReader.test.js
+++ b/tests/readers/RecordAndTupleReader.test.js
@@ -1,0 +1,25 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { RecordAndTupleReader } from "../../src/lexer/RecordAndTupleReader.js";
+
+ test("RecordAndTupleReader reads tuple start", () => {
+   const stream = new CharStream("#[");
+   const tok = RecordAndTupleReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok.type).toBe("TUPLE_START");
+   expect(tok.value).toBe("#[");
+ });
+
+ test("RecordAndTupleReader reads record start", () => {
+   const stream = new CharStream("#{");
+   const tok = RecordAndTupleReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok.type).toBe("RECORD_START");
+   expect(tok.value).toBe("#{");
+ });
+
+ test("RecordAndTupleReader returns null when not matched", () => {
+   const stream = new CharStream("#a");
+   const pos = stream.getPosition();
+   const tok = RecordAndTupleReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok).toBeNull();
+   expect(stream.getPosition()).toEqual(pos);
+ });


### PR DESCRIPTION
## Summary
- add `RecordAndTupleReader` for `#{` and `#[` sequences
- wire new reader into `LexerEngine`
- test new reader and integration behavior
- document record and tuple literals in lexer spec
- check off completed TODO item

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853f345d58083319b7556cb6a109cfc