### PR TITLE
Add Unicode property escape support

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -67,6 +67,9 @@ Each is a pure function `(stream, factory) => Token|null`:
 - Named capture groups using the syntax `(?<name>...)` are recognized. Capture
   group names must follow identifier rules (letters, digits, underscore) and
   invalid names cause the lexer to emit an `INVALID_REGEX` token.
+- Unicode property escapes using `\p{}` and `\P{}` are validated against
+  canonical Unicode property names and values. Unknown properties result
+  in an `INVALID_REGEX` token.
 - Template strings track nested `${ ... }` braces and handle escapes.
 - `HTML_TEMPLATE_STRING` tokens are returned for `html`-tagged templates.
 - `NumberReader` only parses base‑10 integers and decimals.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -81,10 +81,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [ ] Document record and tuple tokenization in `docs/LEXER_SPEC.md`.
 
 ## 30. Unicode Property Escapes
-- [ ] Extend `RegexOrDivideReader` to support `\p{...}` and `\P{...}` escapes.
-- [ ] Validate property names using Unicode property data.
-- [ ] Provide tests covering positive and negative property escapes.
-- [ ] Document supported properties and limitations.
+- [x] Extend `RegexOrDivideReader` to support `\p{...}` and `\P{...}` escapes.
+- [x] Validate property names using Unicode property data.
+- [x] Provide tests covering positive and negative property escapes.
+- [x] Document supported properties and limitations.
 
 ## 31. HTML Comment Support
 - [ ] Add `HTMLCommentReader` for `<!--` and `-->`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -25,7 +25,7 @@
 - [x] Support named capture groups in regular expressions
 - [x] Recognize import assertion syntax after `import` statements
 - [x] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
-- [ ] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
+- [x] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
 - [ ] Implement HTML comment reader for `<!--` and `-->`
 - [ ] Add ModuleBlockReader for `module { ... }` blocks
 - [ ] Support decimal literals like `123.45m` or `0d123.45`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "experimental-js-lexer",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "^17.0.0",
         "@commitlint/config-conventional": "^17.0.0",
@@ -8156,6 +8160,46 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "dependencies": {
+    "unicode-match-property-ecmascript": "^2.0.0",
+    "unicode-match-property-value-ecmascript": "^2.2.0"
   }
 }

--- a/src/lexer/RegexOrDivideReader.js
+++ b/src/lexer/RegexOrDivideReader.js
@@ -13,6 +13,9 @@ function isIdentifierPart(ch) {
   return isIdentifierStart(ch) || (ch >= '0' && ch <= '9');
 }
 
+import matchProperty from 'unicode-match-property-ecmascript';
+import matchPropertyValue from 'unicode-match-property-value-ecmascript';
+
 export function RegexOrDivideReader(stream, factory) {
   const startPos = stream.getPosition();
   if (stream.current() !== '/') return null;
@@ -57,10 +60,56 @@ export function RegexOrDivideReader(stream, factory) {
     const ch = stream.current();
     if (!escaped) {
       if (ch === '\\') {
-        escaped = true;
-        body += ch;
-        stream.advance();
-        continue;
+        const next = stream.peek();
+        if ((next === 'p' || next === 'P') && stream.peek(2) === '{') {
+          const sign = next;
+          body += '\\' + sign + '{';
+          stream.advance(); // consume '\\'
+          stream.advance(); // consume 'p' or 'P'
+          stream.advance(); // consume '{'
+          let prop = '';
+          while (!stream.eof() && stream.current() !== '}') {
+            const c = stream.current();
+            if (!/[A-Za-z0-9_=^:-]/.test(c)) {
+              const endPos = stream.getPosition();
+              return factory('INVALID_REGEX', `/${body}${prop}`, startPos, endPos);
+            }
+            prop += c;
+            body += c;
+            stream.advance();
+          }
+          if (stream.current() !== '}') {
+            const endPos = stream.getPosition();
+            return factory('INVALID_REGEX', `/${body}${prop}`, startPos, endPos);
+          }
+          body += '}';
+          stream.advance();
+          try {
+            const expr = prop.startsWith('^') ? prop.slice(1) : prop;
+            const sepIndex = expr.indexOf('=') !== -1 ? expr.indexOf('=') : expr.indexOf(':');
+            if (sepIndex !== -1) {
+              const p = expr.slice(0, sepIndex);
+              const v = expr.slice(sepIndex + 1);
+              const canonical = matchProperty(p);
+              matchPropertyValue(canonical, v);
+            } else {
+              try {
+                matchProperty(expr);
+              } catch {
+                matchPropertyValue('General_Category', expr);
+              }
+            }
+          } catch {
+            const endPos = stream.getPosition();
+            return factory('INVALID_REGEX', `/${body}`, startPos, endPos);
+          }
+          continue;
+        } else {
+          escaped = true;
+          body += ch;
+          stream.advance();
+          continue;
+        }
       }
 
       if (inCharClass) {

--- a/tests/readers/RegexOrDivideReader.test.js
+++ b/tests/readers/RegexOrDivideReader.test.js
@@ -184,3 +184,26 @@ test("RegexOrDivideReader handles lookbehind assertions", () => {
   expect(token.type).toBe("REGEX");
   expect(token.value).toBe(src);
 });
+
+test("RegexOrDivideReader handles Unicode property escapes", () => {
+  const src = "/\\p{Letter}+/u";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe(src);
+});
+
+test("RegexOrDivideReader handles negative Unicode property escapes", () => {
+  const src = "/\\P{Script=Latin}/u";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("REGEX");
+  expect(token.value).toBe(src);
+});
+
+test("RegexOrDivideReader rejects unknown Unicode property", () => {
+  const src = "/\\p{UnknownProp}/u";
+  const stream = new CharStream(src);
+  const token = RegexOrDivideReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(token.type).toBe("INVALID_REGEX");
+});


### PR DESCRIPTION
## Summary
- validate Unicode regex property escapes and recognise as part of regexes
- test positive/negative property escapes
- document Unicode property escapes in lexer spec
- mark Unicode property escape tasks done
- install `unicode-match-property-ecmascript` packages for validation

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853f50ee2708331a9a3bde9572f6f62