### PR TITLE
Add HTML comment reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -203,3 +203,20 @@ produces the tokens `[
   RECORD_START("#{"), IDENTIFIER("a"), NUMBER("1"), PUNCTUATION("}"),
   TUPLE_START("#["), NUMBER("1"), PUNCTUATION("]")
 ]`.
+
+## 18. HTML Comments <a name="html-comments"></a>
+When `<!--` or `-->` appears at the start of a line, it is treated like a
+single-line comment. The lexer consumes the rest of the line and emits a
+`COMMENT` token containing the text of the comment.
+
+Example:
+
+```
+<!-- hidden -->
+let x = 1;
+```
+
+produces the tokens `[
+  COMMENT("<!-- hidden -->"), WHITESPACE("\n"), KEYWORD("let"), IDENTIFIER("x"),
+  OPERATOR("="), NUMBER("1"), PUNCTUATION(";")
+]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -87,10 +87,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document supported properties and limitations.
 
 ## 31. HTML Comment Support
-- [ ] Add `HTMLCommentReader` for `<!--` and `-->`.
-- [ ] Allow HTML-style comments at script boundaries.
-- [ ] Add unit tests for start and end comments.
-- [ ] Document in `docs/LEXER_SPEC.md`.
+- [x] Add `HTMLCommentReader` for `<!--` and `-->`.
+- [x] Allow HTML-style comments at script boundaries.
+- [x] Add unit tests for start and end comments.
+- [x] Document in `docs/LEXER_SPEC.md`.
 
 ## 32. Module Block Tokens
 - [ ] Create `ModuleBlockReader` for `module { }` syntax.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -26,7 +26,7 @@
 - [x] Recognize import assertion syntax after `import` statements
 - [x] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
 - [x] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
-- [ ] Implement HTML comment reader for `<!--` and `-->`
+ - [x] Implement HTML comment reader for `<!--` and `-->`
 - [ ] Add ModuleBlockReader for `module { ... }` blocks
 - [ ] Support decimal literals like `123.45m` or `0d123.45`
 - [ ] Tokenize `using` and `await using` statements

--- a/src/lexer/HTMLCommentReader.js
+++ b/src/lexer/HTMLCommentReader.js
@@ -1,0 +1,46 @@
+export function HTMLCommentReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const prevChar = startPos.index > 0 ? stream.input[startPos.index - 1] : null;
+  const atLineStart = startPos.index === 0 || prevChar === '\n';
+  if (!atLineStart) return null;
+
+  // <!-- comment
+  if (
+    stream.current() === '<' &&
+    stream.peek() === '!' &&
+    stream.peek(2) === '-' &&
+    stream.peek(3) === '-'
+  ) {
+    let value = '<!--';
+    stream.advance();
+    stream.advance();
+    stream.advance();
+    stream.advance();
+    while (!stream.eof() && stream.current() !== '\n') {
+      value += stream.current();
+      stream.advance();
+    }
+    const endPos = stream.getPosition();
+    return factory('COMMENT', value, startPos, endPos);
+  }
+
+  // --> comment
+  if (
+    stream.current() === '-' &&
+    stream.peek() === '-' &&
+    stream.peek(2) === '>'
+  ) {
+    let value = '-->';
+    stream.advance();
+    stream.advance();
+    stream.advance();
+    while (!stream.eof() && stream.current() !== '\n') {
+      value += stream.current();
+      stream.advance();
+    }
+    const endPos = stream.getPosition();
+    return factory('COMMENT', value, startPos, endPos);
+  }
+
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -14,6 +14,7 @@ import { PunctuationReader } from './PunctuationReader.js';
 import { TemplateStringReader } from './TemplateStringReader.js';
 import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
+import { HTMLCommentReader } from './HTMLCommentReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
@@ -49,6 +50,7 @@ export class LexerEngine {
     // Mapping of mode -> reader list. Order determines priority.
     this.modes = {
       default: [
+        HTMLCommentReader,
         CommentReader,
         WhitespaceReader,
         ShebangReader,
@@ -75,6 +77,7 @@ export class LexerEngine {
         JSXReader
       ],
       do_block: [
+        HTMLCommentReader,
         CommentReader,
         WhitespaceReader,
         ShebangReader,
@@ -145,6 +148,11 @@ export class LexerEngine {
 
     while (!stream.eof()) {
       // 0. Emit comments
+      const htmlComment = HTMLCommentReader(stream, factory, this);
+      if (htmlComment) {
+        this.lastToken = htmlComment;
+        return htmlComment;
+      }
       const comment = CommentReader(stream, factory, this);
       if (comment) {
         this.lastToken = comment;

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -126,6 +126,13 @@ test("integration: shebang comment", () => {
   expect(toks[0].value).toBe("#!/usr/bin/env node");
 });
 
+test("integration: html comments", () => {
+  const src = "<!-- hidden -->\nlet a = 1;";
+  const toks = tokenize(src);
+  expect(toks[0].type).toBe("COMMENT");
+  expect(toks[0].value).toBe("<!-- hidden -->");
+});
+
 test("integration: pipeline operator", () => {
   const toks = tokenize("a |> b");
   expect(toks.map(t => t.type)).toEqual([

--- a/tests/readers/HTMLCommentReader.test.js
+++ b/tests/readers/HTMLCommentReader.test.js
@@ -1,0 +1,31 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { HTMLCommentReader } from "../../src/lexer/HTMLCommentReader.js";
+
+test("HTMLCommentReader reads <!-- at line start", () => {
+  const src = "<!-- hello\nlet a = 1;";
+  const stream = new CharStream(src);
+  const tok = HTMLCommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("COMMENT");
+  expect(tok.value).toBe("<!-- hello");
+  expect(stream.current()).toBe("\n");
+});
+
+test("HTMLCommentReader reads --> at line start", () => {
+  const src = "--> end\n";
+  const stream = new CharStream(src);
+  const tok = HTMLCommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("COMMENT");
+  expect(tok.value).toBe("--> end");
+  expect(stream.current()).toBe("\n");
+});
+
+test("HTMLCommentReader returns null mid-line", () => {
+  const src = "var a; <!-- hi";
+  const stream = new CharStream(src);
+  for (let i = 0; i < 7; i++) stream.advance();
+  const pos = stream.getPosition();
+  const tok = HTMLCommentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `HTMLCommentReader` for `<!--` and `-->`
- integrate new reader into `LexerEngine`
- document HTML comment behavior
- add tests for HTML comment support
- check off related TODO items

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853f6b4c0f0833181aa54d8ae43521a