### PR TITLE
Add ModuleBlockReader for `module { }`

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -220,3 +220,22 @@ produces the tokens `[
   COMMENT("<!-- hidden -->"), WHITESPACE("\n"), KEYWORD("let"), IDENTIFIER("x"),
   OPERATOR("="), NUMBER("1"), PUNCTUATION(";")
 ]`.
+
+## 19. Module Blocks <a name="module-blocks"></a>
+Module blocks start with the keyword `module` followed by an opening brace.
+When this sequence is encountered the lexer emits a `MODULE_BLOCK_START` token
+and pushes a `module_block` mode. Braces inside the block increment and
+ decrement an internal counter so nested blocks are supported. When the
+matching closing brace is reached a `MODULE_BLOCK_END` token is emitted and the
+mode is popped.
+
+Example:
+
+```javascript
+module { let x = 1; }
+```
+
+produces the tokens `[
+  MODULE_BLOCK_START("module {"), KEYWORD("let"), IDENTIFIER("x"),
+  OPERATOR("="), NUMBER("1"), PUNCTUATION(";"), MODULE_BLOCK_END("}")
+]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -93,10 +93,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document in `docs/LEXER_SPEC.md`.
 
 ## 32. Module Block Tokens
-- [ ] Create `ModuleBlockReader` for `module { }` syntax.
-- [ ] Support nested module blocks.
-- [ ] Add token type definitions and tests.
-- [ ] Document new tokens.
+- [x] Create `ModuleBlockReader` for `module { }` syntax.
+- [x] Support nested module blocks.
+- [x] Add token type definitions and tests.
+- [x] Document new tokens.
 
 ## 33. Decimal Literal Reader
 - [ ] Implement `DecimalLiteralReader` for `123.45m` or `0d123.45`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -27,7 +27,7 @@
 - [x] Add RecordAndTupleReader for `#[...]` and `#{...}` syntax
 - [x] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
  - [x] Implement HTML comment reader for `<!--` and `-->`
-- [ ] Add ModuleBlockReader for `module { ... }` blocks
+- [x] Add ModuleBlockReader for `module { ... }` blocks
 - [ ] Support decimal literals like `123.45m` or `0d123.45`
 - [ ] Tokenize `using` and `await using` statements
 - [ ] Add tokens for pattern matching `match`/`case` syntax

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -20,6 +20,7 @@ import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
 import { DoExpressionReader } from './DoExpressionReader.js';
+import { ModuleBlockReader } from './ModuleBlockReader.js';
 import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { ImportAssertionReader } from './ImportAssertionReader.js';
 import { RecordAndTupleReader } from './RecordAndTupleReader.js';
@@ -56,6 +57,7 @@ export class LexerEngine {
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
+        ModuleBlockReader,
         ImportAssertionReader,
         RecordAndTupleReader,
         IdentifierReader,
@@ -83,6 +85,35 @@ export class LexerEngine {
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
+        ModuleBlockReader,
+        ImportAssertionReader,
+        RecordAndTupleReader,
+        IdentifierReader,
+        UnicodeIdentifierReader,
+        UnicodeEscapeIdentifierReader,
+        HexReader,
+        BinaryReader,
+        OctalReader,
+        BigIntReader,
+        NumericSeparatorReader,
+        ExponentReader,
+        NumberReader,
+        StringReader,
+        RegexOrDivideReader,
+        PipelineOperatorReader,
+        OperatorReader,
+        PunctuationReader,
+        TemplateStringReader,
+        JSXReader
+      ],
+      module_block: [
+        HTMLCommentReader,
+        CommentReader,
+        WhitespaceReader,
+        ShebangReader,
+        PrivateIdentifierReader,
+        DoExpressionReader,
+        ModuleBlockReader,
         ImportAssertionReader,
         RecordAndTupleReader,
         IdentifierReader,

--- a/src/lexer/ModuleBlockReader.js
+++ b/src/lexer/ModuleBlockReader.js
@@ -1,0 +1,52 @@
+export function ModuleBlockReader(stream, factory, engine) {
+  const startPos = stream.getPosition();
+
+  if (engine && engine.currentMode && engine.currentMode() === 'module_block') {
+    if (stream.current() === '{') {
+      engine.moduleBlockDepth = (engine.moduleBlockDepth || 0) + 1;
+      return null;
+    }
+    if (stream.current() === '}') {
+      if (engine.moduleBlockDepth > 0) {
+        engine.moduleBlockDepth--;
+        return null;
+      }
+      stream.advance();
+      const endPos = stream.getPosition();
+      engine.popMode();
+      return factory('MODULE_BLOCK_END', '}', startPos, endPos);
+    }
+  }
+
+  if (!stream.input.startsWith('module', stream.index)) return null;
+
+  const savedPos = stream.getPosition();
+  for (const ch of 'module') {
+    if (stream.current() !== ch) {
+      stream.setPosition(savedPos);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next !== '{' && !(/\s/.test(next))) {
+    stream.setPosition(savedPos);
+    return null;
+  }
+
+  while (!stream.eof() && /\s/.test(stream.current())) {
+    stream.advance();
+  }
+
+  if (stream.current() !== '{') {
+    stream.setPosition(savedPos);
+    return null;
+  }
+
+  stream.advance();
+  engine && engine.pushMode && engine.pushMode('module_block');
+  engine.moduleBlockDepth = 0;
+  const endPos = stream.getPosition();
+  return factory('MODULE_BLOCK_START', 'module {', startPos, endPos);
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -201,3 +201,16 @@ test("integration: record and tuple literals", () => {
   ]);
 });
 
+
+test("integration: module blocks", () => {
+  const toks = tokenize("module { let x = 1; }");
+  expect(toks.map(t => t.type)).toEqual([
+    "MODULE_BLOCK_START",
+    "KEYWORD",
+    "IDENTIFIER",
+    "OPERATOR",
+    "NUMBER",
+    "PUNCTUATION",
+    "MODULE_BLOCK_END"
+  ]);
+});

--- a/tests/readers/ModuleBlockReader.test.js
+++ b/tests/readers/ModuleBlockReader.test.js
@@ -1,0 +1,56 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ModuleBlockReader } from "../../src/lexer/ModuleBlockReader.js";
+
+const dummyEngine = {
+  stateStack: ['default'],
+  pushMode(mode) { this.stateStack.push(mode); },
+  popMode() { this.stateStack.pop(); },
+  currentMode() { return this.stateStack[this.stateStack.length - 1]; }
+};
+
+test("ModuleBlockReader reads module block start", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("module { }");
+  const tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("MODULE_BLOCK_START");
+  expect(tok.value).toBe("module {");
+  expect(engine.currentMode()).toBe("module_block");
+});
+
+test("ModuleBlockReader emits end token at closing brace", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("module { }");
+  const startTok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(startTok.type).toBe("MODULE_BLOCK_START");
+  stream.advance();
+  const tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok.type).toBe("MODULE_BLOCK_END");
+  expect(engine.currentMode()).toBe("default");
+});
+
+test("ModuleBlockReader supports nested blocks", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("module { module { } }");
+  const first = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(first.type).toBe("MODULE_BLOCK_START");
+  stream.advance();
+  const nested = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(nested.type).toBe("MODULE_BLOCK_START");
+  stream.advance();
+  const endNested = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(endNested.type).toBe("MODULE_BLOCK_END");
+  stream.advance();
+  const endOuter = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(endOuter.type).toBe("MODULE_BLOCK_END");
+  expect(engine.currentMode()).toBe("default");
+});
+
+test("ModuleBlockReader returns null when not matched", () => {
+  const engine = { ...dummyEngine, stateStack: ['default'] };
+  const stream = new CharStream("mod {} ");
+  const pos = stream.getPosition();
+  const tok = ModuleBlockReader(stream, (t,v,s,e) => new Token(t,v,s,e), engine);
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `ModuleBlockReader` with nested block support
- integrate new reader into `LexerEngine`
- test module block tokenization at reader and integration level
- document module blocks in the lexer spec
- mark TODO checklist and task breakdown items as completed

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6853f8739d108331afc852bb2d29d2d2