### PR TITLE
Add Decimal Literal Reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -74,6 +74,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `HTML_TEMPLATE_STRING` tokens are returned for `html`-tagged templates.
 - `NumberReader` only parses base‑10 integers and decimals.
 - `BigIntReader` parses integer literals with a trailing `n`.
+- `DecimalLiteralReader` parses decimal literals like `123.4m` or `0d123.4`.
 - `HexReader` parses `0x` or `0X` prefixed hexadecimal integers.
 - `OctalReader` parses `0o` or `0O` prefixed octal integers.
 - `ExponentReader` parses numbers with `e` or `E` exponents.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -99,9 +99,9 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document new tokens.
 
 ## 33. Decimal Literal Reader
-- [ ] Implement `DecimalLiteralReader` for `123.45m` or `0d123.45`.
-- [ ] Add tokens and numeric tests.
-- [ ] Update documentation for decimal notation.
+- [x] Implement `DecimalLiteralReader` for `123.45m` or `0d123.45`.
+- [x] Add tokens and numeric tests.
+- [x] Update documentation for decimal notation.
 
 ## 34. Explicit Resource Management
 - [ ] Tokenize `using` and `await using` constructs.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -28,6 +28,6 @@
 - [x] Support Unicode property escapes `\p{}` and `\P{}` in regular expressions
  - [x] Implement HTML comment reader for `<!--` and `-->`
 - [x] Add ModuleBlockReader for `module { ... }` blocks
-- [ ] Support decimal literals like `123.45m` or `0d123.45`
+- [x] Support decimal literals like `123.45m` or `0d123.45`
 - [ ] Tokenize `using` and `await using` statements
 - [ ] Add tokens for pattern matching `match`/`case` syntax

--- a/src/lexer/DecimalLiteralReader.js
+++ b/src/lexer/DecimalLiteralReader.js
@@ -1,0 +1,71 @@
+export function DecimalLiteralReader(stream, factory) {
+  const startPos = stream.getPosition();
+  let ch = stream.current();
+
+  // prefix form 0d123.45
+  if (ch === '0' && (stream.peek() === 'd' || stream.peek() === 'D')) {
+    // ensure digits after prefix
+    const firstDigit = stream.peek(2);
+    if (firstDigit === null || firstDigit < '0' || firstDigit > '9') return null;
+
+    let value = '0' + stream.peek();
+    stream.advance(); // 0
+    stream.advance(); // d or D
+    ch = stream.current();
+    while (ch !== null && ch >= '0' && ch <= '9') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+    if (ch === '.') {
+      value += '.';
+      stream.advance();
+      ch = stream.current();
+      if (ch === null || ch < '0' || ch > '9') {
+        stream.setPosition(startPos);
+        return null;
+      }
+      while (ch !== null && ch >= '0' && ch <= '9') {
+        value += ch;
+        stream.advance();
+        ch = stream.current();
+      }
+    }
+    const endPos = stream.getPosition();
+    return factory('DECIMAL', value, startPos, endPos);
+  }
+
+  // suffix form 123.45m or 123m
+  if (ch !== null && ch >= '0' && ch <= '9') {
+    let value = '';
+    while (ch !== null && ch >= '0' && ch <= '9') {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+    if (ch === '.') {
+      value += '.';
+      stream.advance();
+      ch = stream.current();
+      if (ch === null || ch < '0' || ch > '9') {
+        stream.setPosition(startPos);
+        return null;
+      }
+      while (ch !== null && ch >= '0' && ch <= '9') {
+        value += ch;
+        stream.advance();
+        ch = stream.current();
+      }
+    }
+    if (ch === 'm' || ch === 'M') {
+      value += ch;
+      stream.advance();
+      const endPos = stream.getPosition();
+      return factory('DECIMAL', value, startPos, endPos);
+    }
+  }
+
+  // not a decimal literal
+  stream.setPosition(startPos);
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -3,6 +3,7 @@ import { BinaryReader } from './BinaryReader.js';
 import { OctalReader } from './OctalReader.js';
 import { HexReader } from './HexReader.js';
 import { BigIntReader } from './BigIntReader.js';
+import { DecimalLiteralReader } from './DecimalLiteralReader.js';
 import { NumericSeparatorReader } from './NumericSeparatorReader.js';
 import { ExponentReader } from './ExponentReader.js';
 import { NumberReader } from './NumberReader.js';
@@ -67,6 +68,7 @@ export class LexerEngine {
         BinaryReader,
         OctalReader,
         BigIntReader,
+        DecimalLiteralReader,
         NumericSeparatorReader,
         ExponentReader,
         NumberReader,
@@ -95,6 +97,7 @@ export class LexerEngine {
         BinaryReader,
         OctalReader,
         BigIntReader,
+        DecimalLiteralReader,
         NumericSeparatorReader,
         ExponentReader,
         NumberReader,
@@ -123,6 +126,7 @@ export class LexerEngine {
         BinaryReader,
         OctalReader,
         BigIntReader,
+        DecimalLiteralReader,
         NumericSeparatorReader,
         ExponentReader,
         NumberReader,

--- a/tests/readers/DecimalLiteralReader.test.js
+++ b/tests/readers/DecimalLiteralReader.test.js
@@ -1,0 +1,43 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { DecimalLiteralReader } from "../../src/lexer/DecimalLiteralReader.js";
+
+test("DecimalLiteralReader reads suffix form", () => {
+  const stream = new CharStream("123.45m");
+  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("DECIMAL");
+  expect(tok.value).toBe("123.45m");
+  expect(stream.getPosition().index).toBe(7);
+});
+
+test("DecimalLiteralReader reads prefix form", () => {
+  const stream = new CharStream("0d123.45");
+  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("DECIMAL");
+  expect(tok.value).toBe("0d123.45");
+  expect(stream.getPosition().index).toBe(8);
+});
+
+test("DecimalLiteralReader reads integer suffix", () => {
+  const stream = new CharStream("42m");
+  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("DECIMAL");
+  expect(tok.value).toBe("42m");
+  expect(stream.getPosition().index).toBe(3);
+});
+
+test("DecimalLiteralReader reads integer prefix", () => {
+  const stream = new CharStream("0d123");
+  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("DECIMAL");
+  expect(tok.value).toBe("0d123");
+  expect(stream.getPosition().index).toBe(5);
+});
+
+test("DecimalLiteralReader returns null when invalid", () => {
+  const stream = new CharStream("0d");
+  const pos = stream.getPosition();
+  const tok = DecimalLiteralReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `DecimalLiteralReader` for decimal numbers with `m` suffix or `0d` prefix
- wire new reader into `LexerEngine`
- document decimal literals in lexer spec
- update task lists
- add tests for decimal literals

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6853f9dded2083318c6485202e8d4a0b