### PR TITLE
feat: add pattern matching tokens

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -261,3 +261,19 @@ produces the tokens `[
   AWAIT_USING("await using"), IDENTIFIER("conn"),
   ...
 ]`.
+
+## 21. Pattern Matching Tokens <a name="pattern-matching"></a>
+The lexer reserves the keywords `match` and `case` for future pattern
+matching syntax. When these keywords appear outside of identifiers the lexer
+emits dedicated `MATCH` and `CASE` tokens.
+
+Example:
+
+```javascript
+match (x) { case 1: }
+```
+
+produces the tokens `[
+  MATCH("match"), PUNCTUATION("("), IDENTIFIER("x"), PUNCTUATION(")"),
+  PUNCTUATION("{"), CASE("case"), NUMBER("1"), PUNCTUATION(":"), PUNCTUATION("}")
+]`.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -109,6 +109,6 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document behavior in `docs/LEXER_SPEC.md`.
 
 ## 35. Pattern Matching Tokens
-- [ ] Add `match` and `case` tokens for future pattern matching.
-- [ ] Add tokenization tests.
-- [ ] Document reserved keywords.
+- [x] Add `match` and `case` tokens for future pattern matching.
+- [x] Add tokenization tests.
+- [x] Document reserved keywords.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -30,4 +30,4 @@
 - [x] Add ModuleBlockReader for `module { ... }` blocks
 - [x] Support decimal literals like `123.45m` or `0d123.45`
 - [x] Tokenize `using` and `await using` statements
-- [ ] Add tokens for pattern matching `match`/`case` syntax
+ - [x] Add tokens for pattern matching `match`/`case` syntax

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -26,6 +26,7 @@ import { UsingStatementReader } from './UsingStatementReader.js';
 import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { ImportAssertionReader } from './ImportAssertionReader.js';
 import { RecordAndTupleReader } from './RecordAndTupleReader.js';
+import { PatternMatchReader } from './PatternMatchReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -63,6 +64,7 @@ export class LexerEngine {
         UsingStatementReader,
         ImportAssertionReader,
         RecordAndTupleReader,
+        PatternMatchReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -93,6 +95,7 @@ export class LexerEngine {
         UsingStatementReader,
         ImportAssertionReader,
         RecordAndTupleReader,
+        PatternMatchReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,
@@ -123,6 +126,7 @@ export class LexerEngine {
         UsingStatementReader,
         ImportAssertionReader,
         RecordAndTupleReader,
+        PatternMatchReader,
         IdentifierReader,
         UnicodeIdentifierReader,
         UnicodeEscapeIdentifierReader,

--- a/src/lexer/PatternMatchReader.js
+++ b/src/lexer/PatternMatchReader.js
@@ -1,0 +1,31 @@
+export function PatternMatchReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const prevIndex = startPos.index - 1;
+  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
+  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+
+  function tryWord(word, type) {
+    const saved = stream.getPosition();
+    let value = '';
+    for (const ch of word) {
+      if (stream.current() !== ch) {
+        stream.setPosition(saved);
+        return null;
+      }
+      value += ch;
+      stream.advance();
+    }
+    const next = stream.current();
+    if (next && /[A-Za-z0-9_$]/.test(next)) {
+      stream.setPosition(saved);
+      return null;
+    }
+    const endPos = stream.getPosition();
+    return factory(type, value, startPos, endPos);
+  }
+
+  return (
+    tryWord('match', 'MATCH') ||
+    tryWord('case', 'CASE')
+  );
+}

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -224,3 +224,17 @@ test("integration: await using statement", () => {
   const toks = tokenize("await using y = bar();");
   expect(toks[0].type).toBe("AWAIT_USING");
 });
+
+test("integration: pattern matching tokens", () => {
+  const toks = tokenize("match (x) { case 1: }", { });
+  expect(toks.map(t => t.type)).toEqual([
+    "MATCH",
+    "PUNCTUATION",
+    "IDENTIFIER",
+    "PUNCTUATION",
+    "PUNCTUATION",
+    "CASE",
+    "NUMBER",
+    "PUNCTUATION"
+  ]);
+});

--- a/tests/readers/PatternMatchReader.test.js
+++ b/tests/readers/PatternMatchReader.test.js
@@ -1,0 +1,26 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { PatternMatchReader } from "../../src/lexer/PatternMatchReader.js";
+
+test("PatternMatchReader reads match", () => {
+  const stream = new CharStream("match x");
+  const tok = PatternMatchReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("MATCH");
+  expect(tok.value).toBe("match");
+});
+
+test("PatternMatchReader reads case", () => {
+  const stream = new CharStream("case 1:");
+  const tok = PatternMatchReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("CASE");
+  expect(tok.value).toBe("case");
+});
+
+test("PatternMatchReader returns null inside identifier", () => {
+  const stream = new CharStream("encase");
+  stream.advance();
+  const pos = stream.getPosition();
+  const tok = PatternMatchReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- add `PatternMatchReader` to emit MATCH and CASE tokens
- wire pattern matching reader into LexerEngine
- test pattern matching tokens
- document new reserved keywords
- update task checklist

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853fdfc62ec83319a435ed42585a5d1