### PR TITLE
Add FunctionSentReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -279,3 +279,19 @@ produces the tokens `[
   PUNCTUATION("}")
 ]`.
 
+## 22. Function.sent <a name="function-sent"></a>
+Generator functions may access the `function.sent` meta property to
+retrieve the value supplied by the most recent `next()` call. When the
+lexer encounters the exact sequence `function.sent` it emits a
+`FUNCTION_SENT` token.
+
+Example:
+
+```javascript
+function.sent;
+```
+
+produces the tokens `[
+  FUNCTION_SENT("function.sent"), PUNCTUATION(";")
+]`.
+

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -114,10 +114,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document reserved keywords.
 
 ## 36. Function.sent Meta Property
-- [ ] Create `FunctionSentReader` to recognize `function.sent`.
-- [ ] Register the reader in default mode for generator functions.
-- [ ] Write unit tests covering `function.sent` usage.
-- [ ] Document the new token in `docs/LEXER_SPEC.md`.
+- [x] Create `FunctionSentReader` to recognize `function.sent`.
+- [x] Register the reader in default mode for generator functions.
+- [x] Write unit tests covering `function.sent` usage.
+- [x] Document the new token in `docs/LEXER_SPEC.md`.
 
 ## 37. Bind Operator
 - [ ] Implement `BindOperatorReader` emitting `BIND_OPERATOR` for `::`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -34,7 +34,7 @@
 
 #### Proposed Future Enhancements
 
-- [ ] Implement FunctionSentReader for `function.sent` meta property
+- [x] Implement FunctionSentReader for `function.sent` meta property
 - [ ] Add BindOperatorReader for `::` method binding
 - [ ] Extend RegexOrDivideReader to support Unicode sets with the `v` flag
 - [ ] Provide FlowTypePlugin for Flow-specific syntax

--- a/src/lexer/FunctionSentReader.js
+++ b/src/lexer/FunctionSentReader.js
@@ -1,0 +1,27 @@
+export function FunctionSentReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const prevIndex = startPos.index - 1;
+  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
+  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+
+  const seq = 'function.sent';
+  if (!stream.input.startsWith(seq, startPos.index)) return null;
+
+  const saved = stream.getPosition();
+  for (const ch of seq) {
+    if (stream.current() !== ch) {
+      stream.setPosition(saved);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next && /[A-Za-z0-9_$]/.test(next)) {
+    stream.setPosition(saved);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('FUNCTION_SENT', seq, startPos, endPos);
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -27,6 +27,7 @@ import { PatternMatchReader } from './PatternMatchReader.js';
 import { PrivateIdentifierReader } from './PrivateIdentifierReader.js';
 import { ImportAssertionReader } from './ImportAssertionReader.js';
 import { RecordAndTupleReader } from './RecordAndTupleReader.js';
+import { FunctionSentReader } from './FunctionSentReader.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
@@ -63,6 +64,7 @@ export class LexerEngine {
         ModuleBlockReader,
         UsingStatementReader,
         PatternMatchReader,
+        FunctionSentReader,
         ImportAssertionReader,
         RecordAndTupleReader,
         IdentifierReader,
@@ -94,6 +96,7 @@ export class LexerEngine {
         ModuleBlockReader,
         UsingStatementReader,
         PatternMatchReader,
+        FunctionSentReader,
         ImportAssertionReader,
         RecordAndTupleReader,
         IdentifierReader,
@@ -125,6 +128,7 @@ export class LexerEngine {
         ModuleBlockReader,
         UsingStatementReader,
         PatternMatchReader,
+        FunctionSentReader,
         ImportAssertionReader,
         RecordAndTupleReader,
         IdentifierReader,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -238,3 +238,11 @@ test("integration: pattern matching tokens", () => {
     "PUNCTUATION"
   ]);
 });
+
+test("integration: function.sent meta property", () => {
+  const toks = tokenize("function.sent;");
+  expect(toks.map(t => t.type)).toEqual([
+    "FUNCTION_SENT",
+    "PUNCTUATION"
+  ]);
+});

--- a/tests/readers/FunctionSentReader.test.js
+++ b/tests/readers/FunctionSentReader.test.js
@@ -1,0 +1,28 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { FunctionSentReader } from "../../src/lexer/FunctionSentReader.js";
+
+test("FunctionSentReader reads function.sent", () => {
+  const stream = new CharStream("function.sent");
+  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("FUNCTION_SENT");
+  expect(tok.value).toBe("function.sent");
+});
+
+test("FunctionSentReader returns null when sequence not matched", () => {
+  const stream = new CharStream("function.send");
+  const pos = stream.getPosition();
+  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});
+
+test("FunctionSentReader returns null inside identifier", () => {
+  const stream = new CharStream("myfunction.sent");
+  stream.advance();
+  stream.advance();
+  const pos = stream.getPosition();
+  const tok = FunctionSentReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `FunctionSentReader` to recognize `function.sent`
- register new reader in `LexerEngine`
- document `FUNCTION_SENT` token
- test new reader and integration
- check off TODO items

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6854021488ec8331a9d9990d52c86a9d