### PR TITLE
Add BindOperatorReader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -140,7 +140,20 @@ a |> b
 
 produces the tokens `[IDENTIFIER("a"), PIPELINE_OPERATOR("|>"), IDENTIFIER("b")]`.
 
-## 14. Do Expressions <a name="do-expressions"></a>
+## 14. Bind Operator <a name="bind"></a>
+The bind operator `::` allows convenient method extraction without losing the
+object context. When the lexer encounters the sequence `::` it emits a distinct
+`BIND_OPERATOR` token.
+
+Example:
+
+```
+obj::method
+```
+
+produces the tokens `[IDENTIFIER("obj"), BIND_OPERATOR("::"), IDENTIFIER("method")]`.
+
+## 15. Do Expressions <a name="do-expressions"></a>
 Do expressions allow block scoped evaluation returning the last statement value. When the lexer encounters the keyword `do` followed by an opening brace, it emits a `DO_BLOCK_START` token and pushes a `do_block` mode on the state stack. The body of the block is tokenized normally. Each closing brace decrements an internal counter and when the matching brace is reached a `DO_BLOCK_END` token is emitted and the mode is popped. Nested `do` blocks are therefore handled correctly.
 
 Example:
@@ -151,7 +164,7 @@ do { 1 + 2 }
 
 produces the tokens `[DO_BLOCK_START("do {"), NUMBER("1"), OPERATOR("+"), NUMBER("2"), DO_BLOCK_END("}")]`.
 
-## 15. Private Identifiers <a name="private-identifiers"></a>
+## 16. Private Identifiers <a name="private-identifiers"></a>
 Private class fields and methods begin with a `#` prefix. When the lexer
 encounters `#` followed by an identifier, it emits a `PRIVATE_IDENTIFIER`
 token containing the full sequence including the hash.
@@ -169,7 +182,7 @@ produces the tokens `[
   PUNCTUATION("{"), PUNCTUATION("}"), PUNCTUATION("}")
 ]`.
 
-## 16. Import Assertions <a name="import-assertions"></a>
+## 17. Import Assertions <a name="import-assertions"></a>
 Import statements may include an `assert` clause to provide metadata about the
 module being imported. The lexer recognizes the sequence `assert { ... }` (or
 `assert: { ... }` inside dynamic import options) as a single
@@ -187,7 +200,7 @@ produces the tokens `[
   PUNCTUATION(";")
 ]`.
 
-## 17. Record and Tuple Literals <a name="record-tuple"></a>
+## 18. Record and Tuple Literals <a name="record-tuple"></a>
 Record (`#{}`) and tuple (`#[ ]`) literals start with `#` followed by
 `{` or `[`.
 When these sequences are encountered, the lexer emits a `RECORD_START`
@@ -206,7 +219,7 @@ produces the tokens `[
   TUPLE_START("#["), NUMBER("1"), PUNCTUATION("]")
 ]`.
 
-## 18. HTML Comments <a name="html-comments"></a>
+## 19. HTML Comments <a name="html-comments"></a>
 When `<!--` or `-->` appears at the start of a line, it is treated like a
 single-line comment. The lexer consumes the rest of the line and emits a
 `COMMENT` token containing the text of the comment.
@@ -223,7 +236,7 @@ produces the tokens `[
   OPERATOR("="), NUMBER("1"), PUNCTUATION(";")
 ]`.
 
-## 19. Module Blocks <a name="module-blocks"></a>
+## 20. Module Blocks <a name="module-blocks"></a>
 Module blocks start with the keyword `module` followed by an opening brace.
 When this sequence is encountered the lexer emits a `MODULE_BLOCK_START` token
 and pushes a `module_block` mode. Braces inside the block increment and
@@ -242,7 +255,7 @@ produces the tokens `[
   OPERATOR("="), NUMBER("1"), PUNCTUATION(";"), MODULE_BLOCK_END("}")
 ]`.
 
-## 20. Explicit Resource Management <a name="using"></a>
+## 21. Explicit Resource Management <a name="using"></a>
 The lexer recognizes the experimental `using` declarations for managing
 resources. When the keyword `using` appears at the start of a statement it
 emits a `USING` token. If the sequence is preceded by `await` separated by
@@ -262,7 +275,7 @@ produces the tokens `[
   ...
 ]`.
 
-## 21. Pattern Matching <a name="pattern-matching"></a>
+## 22. Pattern Matching <a name="pattern-matching"></a>
 The lexer reserves the keywords `match` and `case` for future pattern
 matching support. When these words appear at statement boundaries they
 are emitted as `MATCH` and `CASE` tokens respectively.
@@ -279,7 +292,7 @@ produces the tokens `[
   PUNCTUATION("}")
 ]`.
 
-## 22. Function.sent <a name="function-sent"></a>
+## 23. Function.sent <a name="function-sent"></a>
 Generator functions may access the `function.sent` meta property to
 retrieve the value supplied by the most recent `next()` call. When the
 lexer encounters the exact sequence `function.sent` it emits a

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -120,10 +120,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document the new token in `docs/LEXER_SPEC.md`.
 
 ## 37. Bind Operator
-- [ ] Implement `BindOperatorReader` emitting `BIND_OPERATOR` for `::`.
-- [ ] Integrate the reader near the pipeline operator in `LexerEngine`.
-- [ ] Add tests like `obj::method` tokenization.
-- [ ] Document operator semantics.
+- [x] Implement `BindOperatorReader` emitting `BIND_OPERATOR` for `::`.
+- [x] Integrate the reader near the pipeline operator in `LexerEngine`.
+- [x] Add tests like `obj::method` tokenization.
+- [x] Document operator semantics.
 
 ## 38. RegExp Unicode Sets
 - [ ] Extend `RegexOrDivideReader` to parse Unicode sets under the `v` flag.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -35,7 +35,7 @@
 #### Proposed Future Enhancements
 
 - [x] Implement FunctionSentReader for `function.sent` meta property
-- [ ] Add BindOperatorReader for `::` method binding
+- [x] Add BindOperatorReader for `::` method binding
 - [ ] Extend RegexOrDivideReader to support Unicode sets with the `v` flag
 - [ ] Provide FlowTypePlugin for Flow-specific syntax
 

--- a/src/lexer/BindOperatorReader.js
+++ b/src/lexer/BindOperatorReader.js
@@ -1,0 +1,10 @@
+export function BindOperatorReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.current() === ':' && stream.peek() === ':') {
+    stream.advance();
+    stream.advance();
+    const endPos = stream.getPosition();
+    return factory('BIND_OPERATOR', '::', startPos, endPos);
+  }
+  return null;
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -9,6 +9,7 @@ import { ExponentReader } from './ExponentReader.js';
 import { NumberReader } from './NumberReader.js';
 import { StringReader } from './StringReader.js';
 import { RegexOrDivideReader } from './RegexOrDivideReader.js';
+import { BindOperatorReader } from './BindOperatorReader.js';
 import { PipelineOperatorReader } from './PipelineOperatorReader.js';
 import { OperatorReader } from './OperatorReader.js';
 import { PunctuationReader } from './PunctuationReader.js';
@@ -81,6 +82,7 @@ export class LexerEngine {
         StringReader,
         RegexOrDivideReader,
         PipelineOperatorReader,
+        BindOperatorReader,
         OperatorReader,
         PunctuationReader,
         TemplateStringReader,
@@ -113,6 +115,7 @@ export class LexerEngine {
         StringReader,
         RegexOrDivideReader,
         PipelineOperatorReader,
+        BindOperatorReader,
         OperatorReader,
         PunctuationReader,
         TemplateStringReader,
@@ -145,6 +148,7 @@ export class LexerEngine {
         StringReader,
         RegexOrDivideReader,
         PipelineOperatorReader,
+        BindOperatorReader,
         OperatorReader,
         PunctuationReader,
         TemplateStringReader,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -142,6 +142,15 @@ test("integration: pipeline operator", () => {
   ]);
 });
 
+test("integration: bind operator", () => {
+  const toks = tokenize("obj::method");
+  expect(toks.map(t => t.type)).toEqual([
+    "IDENTIFIER",
+    "BIND_OPERATOR",
+    "IDENTIFIER"
+  ]);
+});
+
 test("integration: private identifiers", () => {
   const toks = tokenize("class C { #a; #b() {} }");
   expect(toks.map(t => t.type)).toEqual([

--- a/tests/readers/BindOperatorReader.test.js
+++ b/tests/readers/BindOperatorReader.test.js
@@ -1,0 +1,18 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { BindOperatorReader } from "../../src/lexer/BindOperatorReader.js";
+
+test("BindOperatorReader reads :: operator", () => {
+  const stream = new CharStream("::");
+  const tok = BindOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BIND_OPERATOR");
+  expect(tok.value).toBe("::");
+});
+
+test("BindOperatorReader returns null when sequence not matched", () => {
+  const stream = new CharStream("?:");
+  const pos = stream.getPosition();
+  const tok = BindOperatorReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement BindOperatorReader for the `::` syntax
- wire BindOperatorReader into LexerEngine
- add unit and integration tests
- document bind operator usage
- update todo lists

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685403c535d88331a8ae6ef5bfe72da9