### PR TITLE
Add Flow type plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ import { TypeScriptPlugin } from './src/plugins/typescript/TypeScriptPlugin.js';
 registerPlugin(TypeScriptPlugin);
 ```
 
+Similarly you can enable Flow type annotations:
+
+```javascript
+import { FlowTypePlugin } from './src/plugins/flow/FlowTypePlugin.js';
+registerPlugin(FlowTypePlugin);
+```
+
 See `docs/PLUGIN_API.md` for details on authoring plugins.
 
 ## Auto-Merge Workflow

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -78,3 +78,13 @@ import { TypeScriptPlugin } from './src/plugins/typescript/TypeScriptPlugin.js';
 
 registerPlugin(TypeScriptPlugin);
 ```
+
+## Flow Type Plugin
+
+The `FlowTypePlugin` adds a reader for Flow-style type annotations. Unlike the TypeScript plugin it leaves JSX parsing enabled so Flow code can coexist with React components.
+
+```javascript
+import { FlowTypePlugin } from './src/plugins/flow/FlowTypePlugin.js';
+
+registerPlugin(FlowTypePlugin);
+```

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -132,10 +132,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document support in regex section.
 
 ## 39. Flow Type Plugin
-- [ ] Provide `FlowTypePlugin` with readers for Flow annotations.
-- [ ] Allow enabling Flow mode without interfering with JSX.
-- [ ] Document plugin usage and examples.
-- [ ] Add unit tests for Flow-specific tokens.
+- [x] Provide `FlowTypePlugin` with readers for Flow annotations.
+- [x] Allow enabling Flow mode without interfering with JSX.
+- [x] Document plugin usage and examples.
+- [x] Add unit tests for Flow-specific tokens.
 
 ## 40. Byte Order Mark Handling
 - [ ] Implement `ByteOrderMarkReader` for files starting with `\uFEFF`.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -37,7 +37,7 @@
 - [x] Implement FunctionSentReader for `function.sent` meta property
 - [x] Add BindOperatorReader for `::` method binding
  - [x] Extend RegexOrDivideReader to support Unicode sets with the `v` flag
-- [ ] Provide FlowTypePlugin for Flow-specific syntax
+- [x] Provide FlowTypePlugin for Flow-specific syntax
 
 ##### Additional Lexical Improvements
 

--- a/src/plugins/flow/FlowTypePlugin.js
+++ b/src/plugins/flow/FlowTypePlugin.js
@@ -1,0 +1,24 @@
+export function FlowTypeAnnotationReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== ':') return null;
+  let value = ':';
+  stream.advance();
+  while (stream.current() && /\s/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+  while (stream.current() && /[A-Za-z0-9_<>,\s?]/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+    if (/\n/.test(stream.current())) break;
+  }
+  return factory('TYPE_ANNOTATION', value.trimEnd(), start, stream.getPosition());
+}
+
+export const FlowTypePlugin = {
+  modes: { default: [FlowTypeAnnotationReader] },
+  init(engine) {
+    const orig = engine.modes.default.filter(r => r !== FlowTypeAnnotationReader);
+    engine.modes.default = [FlowTypeAnnotationReader, ...orig];
+  }
+};

--- a/tests/flowTypePlugin.test.js
+++ b/tests/flowTypePlugin.test.js
@@ -1,0 +1,23 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { registerPlugin, clearPlugins } from '../index.js';
+import { FlowTypePlugin } from '../src/plugins/flow/FlowTypePlugin.js';
+
+afterEach(() => {
+  clearPlugins();
+});
+
+test('FlowTypePlugin reads type annotations', () => {
+  registerPlugin(FlowTypePlugin);
+  const engine = new LexerEngine(new CharStream(': string'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('TYPE_ANNOTATION');
+  expect(tok.value).toBe(': string');
+});
+
+test('FlowTypePlugin keeps JSX enabled', () => {
+  registerPlugin(FlowTypePlugin);
+  const engine = new LexerEngine(new CharStream('<div/>'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('JSX_TEXT');
+});


### PR DESCRIPTION
## Summary
- implement FlowTypePlugin for Flow-style annotations
- document FlowTypePlugin and add README example
- update task checklists for Flow plugin
- test FlowTypePlugin functionality

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68540674f0848331ac44f613bbd05029