### PR TITLE
Add Byte Order Mark reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -83,6 +83,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `ExponentReader` parses numbers with `e` or `E` exponents.
 - `UnicodeIdentifierReader` reads identifiers starting with non-ASCII Unicode characters.
 - `UnicodeEscapeIdentifierReader` reads identifiers containing Unicode escape sequences like `\u{1F600}`.
+- `ByteOrderMarkReader` handles a leading `\uFEFF` byte order mark and emits a `BOM` token.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
@@ -309,4 +310,9 @@ function.sent;
 produces the tokens `[
   FUNCTION_SENT("function.sent"), PUNCTUATION(";")
 ]`.
+
+## 24. Byte Order Mark <a name="bom"></a>
+If a file begins with the Unicode byte order mark (`\uFEFF`), the lexer emits a
+`BOM` token and advances past it before processing the rest of the input. The
+token's value is the literal BOM character.
 

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -138,10 +138,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Add unit tests for Flow-specific tokens.
 
 ## 40. Byte Order Mark Handling
-- [ ] Implement `ByteOrderMarkReader` for files starting with `\uFEFF`.
-- [ ] Integrate this reader before ShebangReader in `LexerEngine`.
-- [ ] Add tests ensuring BOM is skipped or tokenized correctly.
-- [ ] Document BOM behavior in `docs/LEXER_SPEC.md`.
+- [x] Implement `ByteOrderMarkReader` for files starting with `\uFEFF`.
+- [x] Integrate this reader before ShebangReader in `LexerEngine`.
+- [x] Add tests ensuring BOM is skipped or tokenized correctly.
+- [x] Document BOM behavior in `docs/LEXER_SPEC.md`.
 
 ## 41. Source Mapping Comment Reader
 - [ ] Create `SourceMappingURLReader` recognizing `//# sourceMappingURL=` comments.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -41,7 +41,7 @@
 
 ##### Additional Lexical Improvements
 
-- [ ] Implement ByteOrderMarkReader for handling BOM at file start
+- [x] Implement ByteOrderMarkReader for handling BOM at file start
 - [ ] Parse `//# sourceMappingURL=` comments for tool integration
 - [ ] Normalize all Unicode whitespace via UnicodeWhitespaceReader
 - [ ] Add ErrorRecoveryMode to skip malformed tokens gracefully

--- a/src/lexer/ByteOrderMarkReader.js
+++ b/src/lexer/ByteOrderMarkReader.js
@@ -1,0 +1,8 @@
+export function ByteOrderMarkReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (stream.index !== 0) return null;
+  if (stream.current() !== '\uFEFF') return null;
+  stream.advance();
+  const endPos = stream.getPosition();
+  return factory('BOM', '\uFEFF', startPos, endPos);
+}

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -18,6 +18,7 @@ import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
 import { HTMLCommentReader } from './HTMLCommentReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
+import { ByteOrderMarkReader } from './ByteOrderMarkReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
 import { ShebangReader } from './ShebangReader.js';
@@ -59,6 +60,7 @@ export class LexerEngine {
         HTMLCommentReader,
         CommentReader,
         WhitespaceReader,
+        ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
@@ -92,6 +94,7 @@ export class LexerEngine {
         HTMLCommentReader,
         CommentReader,
         WhitespaceReader,
+        ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,
@@ -125,6 +128,7 @@ export class LexerEngine {
         HTMLCommentReader,
         CommentReader,
         WhitespaceReader,
+        ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,
         DoExpressionReader,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -126,6 +126,13 @@ test("integration: shebang comment", () => {
   expect(toks[0].value).toBe("#!/usr/bin/env node");
 });
 
+test("integration: byte order mark", () => {
+  const src = "\uFEFFlet a = 1;";
+  const toks = tokenize(src);
+  expect(toks[0].type).toBe("BOM");
+  expect(toks[1].type).toBe("KEYWORD");
+});
+
 test("integration: html comments", () => {
   const src = "<!-- hidden -->\nlet a = 1;";
   const toks = tokenize(src);

--- a/tests/readers/ByteOrderMarkReader.test.js
+++ b/tests/readers/ByteOrderMarkReader.test.js
@@ -1,0 +1,20 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ByteOrderMarkReader } from "../../src/lexer/ByteOrderMarkReader.js";
+
+test("ByteOrderMarkReader consumes BOM at file start", () => {
+  const stream = new CharStream("\uFEFFlet a = 1;");
+  const tok = ByteOrderMarkReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("BOM");
+  expect(tok.value).toBe("\uFEFF");
+  expect(stream.getPosition().index).toBe(1);
+});
+
+test("ByteOrderMarkReader returns null when not at start", () => {
+  const stream = new CharStream("let a = 1;\uFEFF");
+  stream.advance();
+  const pos = stream.getPosition();
+  const tok = ByteOrderMarkReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- implement `ByteOrderMarkReader` for handling `\uFEFF`
- register reader in `LexerEngine` before `ShebangReader`
- update spec with BOM behaviour
- mark TODO and task breakdown items complete
- test reader and integration cases

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685407fad3948331b2e9ae5b45425a3c