### PR TITLE
Add SourceMappingURL reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -85,6 +85,7 @@ Each is a pure function `(stream, factory) => Token|null`:
 - `UnicodeEscapeIdentifierReader` reads identifiers containing Unicode escape sequences like `\u{1F600}`.
 - `ByteOrderMarkReader` handles a leading `\uFEFF` byte order mark and emits a `BOM` token.
 - `ShebangReader` consumes `#!` headers at the start of a file as `COMMENT` tokens.
+- `SourceMappingURLReader` recognizes `//# sourceMappingURL=` comments and emits a `SOURCE_MAPPING_URL` token with the mapping value.
 - `StringReader` parses single- or double-quoted strings with escapes and errors on unterminated input.
 - `JSXReader` tokenizes raw JSX elements between `<` and `>`.
 - `JSXReader` ignores `<` inside `{}` expressions and supports self-closing tags.
@@ -315,4 +316,10 @@ produces the tokens `[
 If a file begins with the Unicode byte order mark (`\uFEFF`), the lexer emits a
 `BOM` token and advances past it before processing the rest of the input. The
 token's value is the literal BOM character.
+
+## 25. Source Mapping Comments <a name="source-maps"></a>
+Comments of the form `//# sourceMappingURL=...` or `/*# sourceMappingURL=... */`
+are consumed by `SourceMappingURLReader`. The lexer emits a
+`SOURCE_MAPPING_URL` token whose value is the provided mapping URL. Both
+external map references and inline data URIs are supported.
 

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -144,10 +144,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document BOM behavior in `docs/LEXER_SPEC.md`.
 
 ## 41. Source Mapping Comment Reader
-- [ ] Create `SourceMappingURLReader` recognizing `//# sourceMappingURL=` comments.
-- [ ] Expose parsed mapping values via a new token type.
-- [ ] Add unit tests for inline and external source maps.
-- [ ] Document usage for build tools.
+- [x] Create `SourceMappingURLReader` recognizing `//# sourceMappingURL=` comments.
+- [x] Expose parsed mapping values via a new token type.
+- [x] Add unit tests for inline and external source maps.
+- [x] Document usage for build tools.
 
 ## 42. Unicode Whitespace Consolidation
 - [ ] Extend `WhitespaceReader` to treat all Unicode spaces equivalently.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -42,6 +42,6 @@
 ##### Additional Lexical Improvements
 
 - [x] Implement ByteOrderMarkReader for handling BOM at file start
-- [ ] Parse `//# sourceMappingURL=` comments for tool integration
+- [x] Parse `//# sourceMappingURL=` comments for tool integration
 - [ ] Normalize all Unicode whitespace via UnicodeWhitespaceReader
 - [ ] Add ErrorRecoveryMode to skip malformed tokens gracefully

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -17,6 +17,7 @@ import { TemplateStringReader } from './TemplateStringReader.js';
 import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
 import { HTMLCommentReader } from './HTMLCommentReader.js';
+import { SourceMappingURLReader } from './SourceMappingURLReader.js';
 import { WhitespaceReader } from './WhitespaceReader.js';
 import { ByteOrderMarkReader } from './ByteOrderMarkReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
@@ -58,6 +59,7 @@ export class LexerEngine {
     this.modes = {
       default: [
         HTMLCommentReader,
+        SourceMappingURLReader,
         CommentReader,
         WhitespaceReader,
         ByteOrderMarkReader,
@@ -92,6 +94,7 @@ export class LexerEngine {
       ],
       do_block: [
         HTMLCommentReader,
+        SourceMappingURLReader,
         CommentReader,
         WhitespaceReader,
         ByteOrderMarkReader,
@@ -126,6 +129,7 @@ export class LexerEngine {
       ],
       module_block: [
         HTMLCommentReader,
+        SourceMappingURLReader,
         CommentReader,
         WhitespaceReader,
         ByteOrderMarkReader,
@@ -207,6 +211,11 @@ export class LexerEngine {
       if (htmlComment) {
         this.lastToken = htmlComment;
         return htmlComment;
+      }
+      const sourceMap = SourceMappingURLReader(stream, factory, this);
+      if (sourceMap) {
+        this.lastToken = sourceMap;
+        return sourceMap;
       }
       const comment = CommentReader(stream, factory, this);
       if (comment) {

--- a/src/lexer/SourceMappingURLReader.js
+++ b/src/lexer/SourceMappingURLReader.js
@@ -1,0 +1,39 @@
+export function SourceMappingURLReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const patterns = [
+    '//# sourceMappingURL=',
+    '//@ sourceMappingURL=',
+    '/*# sourceMappingURL=',
+    '/*@ sourceMappingURL='
+  ];
+  for (const p of patterns) {
+    if (stream.input.startsWith(p, stream.index)) {
+      const isBlock = p.startsWith('/*');
+      for (let i = 0; i < p.length; i++) {
+        stream.advance();
+      }
+      let value = '';
+      if (isBlock) {
+        while (!stream.eof()) {
+          if (stream.current() === '*' && stream.peek() === '/') {
+            break;
+          }
+          value += stream.current();
+          stream.advance();
+        }
+        if (stream.current() === '*' && stream.peek() === '/') {
+          stream.advance();
+          stream.advance();
+        }
+      } else {
+        while (!stream.eof() && stream.current() !== '\n') {
+          value += stream.current();
+          stream.advance();
+        }
+      }
+      const endPos = stream.getPosition();
+      return factory('SOURCE_MAPPING_URL', value.trim(), startPos, endPos);
+    }
+  }
+  return null;
+}

--- a/tests/readers/SourceMappingURLReader.test.js
+++ b/tests/readers/SourceMappingURLReader.test.js
@@ -1,0 +1,36 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { SourceMappingURLReader } from "../../src/lexer/SourceMappingURLReader.js";
+
+test("SourceMappingURLReader reads external map line comment", () => {
+  const stream = new CharStream("//# sourceMappingURL=foo.js.map\n");
+  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("SOURCE_MAPPING_URL");
+  expect(tok.value).toBe("foo.js.map");
+  expect(stream.current()).toBe("\n");
+});
+
+test("SourceMappingURLReader reads inline data URI", () => {
+  const data = "data:application/json;base64,AAAA";
+  const stream = new CharStream(`//# sourceMappingURL=${data}`);
+  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("SOURCE_MAPPING_URL");
+  expect(tok.value).toBe(data);
+  expect(stream.eof()).toBe(true);
+});
+
+test("SourceMappingURLReader reads block comment", () => {
+  const stream = new CharStream("/*# sourceMappingURL=foo.js.map */");
+  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("SOURCE_MAPPING_URL");
+  expect(tok.value).toBe("foo.js.map");
+  expect(stream.eof()).toBe(true);
+});
+
+test("SourceMappingURLReader returns null when not a mapping comment", () => {
+  const stream = new CharStream("// just a comment\n");
+  const pos = stream.getPosition();
+  const tok = SourceMappingURLReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok).toBeNull();
+  expect(stream.getPosition()).toEqual(pos);
+});


### PR DESCRIPTION
## Summary
- add SourceMappingURLReader to parse `//# sourceMappingURL=` comments
- integrate new reader into lexer engine and modes
- document feature and usage
- update task lists
- test SourceMappingURLReader for various comment styles

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6854090e9d488331abc4ce7ead72e20d