### PR TITLE
Implement Unicode whitespace reader

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -323,3 +323,10 @@ are consumed by `SourceMappingURLReader`. The lexer emits a
 `SOURCE_MAPPING_URL` token whose value is the provided mapping URL. Both
 external map references and inline data URIs are supported.
 
+
+## 26. Unicode Whitespace <a name="unicode-whitespace"></a>
+The `UnicodeWhitespaceReader` groups any character with the Unicode `White_Space`
+property into a single `WHITESPACE` token. Consecutive characters—including
+rare spaces such as `\u2003` (EM SPACE) and `\u205F` (MEDIUM MATHEMATICAL
+SPACE)—are consumed together, and the token's value preserves the original
+characters.

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -150,10 +150,10 @@ This document outlines detailed subtasks for each remaining objective in `TODO_C
 - [x] Document usage for build tools.
 
 ## 42. Unicode Whitespace Consolidation
-- [ ] Extend `WhitespaceReader` to treat all Unicode spaces equivalently.
-- [ ] Normalize uncommon spaces like `\u2003` and `\u205F` to a single token type.
-- [ ] Add tests covering various Unicode whitespace characters.
-- [ ] Describe normalization rules in the spec.
+- [x] Extend `WhitespaceReader` to treat all Unicode spaces equivalently.
+- [x] Normalize uncommon spaces like `\u2003` and `\u205F` to a single token type.
+- [x] Add tests covering various Unicode whitespace characters.
+- [x] Describe normalization rules in the spec.
 
 ## 43. Error Recovery Mode
 - [ ] Add an optional lexer mode to skip malformed or unknown tokens.

--- a/docs/TODO_CHECKLIST.md
+++ b/docs/TODO_CHECKLIST.md
@@ -43,5 +43,5 @@
 
 - [x] Implement ByteOrderMarkReader for handling BOM at file start
 - [x] Parse `//# sourceMappingURL=` comments for tool integration
-- [ ] Normalize all Unicode whitespace via UnicodeWhitespaceReader
+- [x] Normalize all Unicode whitespace via UnicodeWhitespaceReader
 - [ ] Add ErrorRecoveryMode to skip malformed tokens gracefully

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -18,7 +18,7 @@ import { JSXReader } from './JSXReader.js';
 import { CommentReader } from './CommentReader.js';
 import { HTMLCommentReader } from './HTMLCommentReader.js';
 import { SourceMappingURLReader } from './SourceMappingURLReader.js';
-import { WhitespaceReader } from './WhitespaceReader.js';
+import { UnicodeWhitespaceReader } from './UnicodeWhitespaceReader.js';
 import { ByteOrderMarkReader } from './ByteOrderMarkReader.js';
 import { UnicodeIdentifierReader } from './UnicodeIdentifierReader.js';
 import { UnicodeEscapeIdentifierReader } from './UnicodeEscapeIdentifierReader.js';
@@ -61,7 +61,7 @@ export class LexerEngine {
         HTMLCommentReader,
         SourceMappingURLReader,
         CommentReader,
-        WhitespaceReader,
+        UnicodeWhitespaceReader,
         ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,
@@ -96,7 +96,7 @@ export class LexerEngine {
         HTMLCommentReader,
         SourceMappingURLReader,
         CommentReader,
-        WhitespaceReader,
+        UnicodeWhitespaceReader,
         ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,
@@ -131,7 +131,7 @@ export class LexerEngine {
         HTMLCommentReader,
         SourceMappingURLReader,
         CommentReader,
-        WhitespaceReader,
+        UnicodeWhitespaceReader,
         ByteOrderMarkReader,
         ShebangReader,
         PrivateIdentifierReader,

--- a/src/lexer/UnicodeWhitespaceReader.js
+++ b/src/lexer/UnicodeWhitespaceReader.js
@@ -1,0 +1,13 @@
+const WS_RE = /\p{White_Space}/u;
+
+export function UnicodeWhitespaceReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (!WS_RE.test(stream.current() || '')) return null;
+  let value = '';
+  while (!stream.eof() && WS_RE.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+  const endPos = stream.getPosition();
+  return factory('WHITESPACE', value, startPos, endPos);
+}

--- a/tests/readers/UnicodeWhitespaceReader.test.js
+++ b/tests/readers/UnicodeWhitespaceReader.test.js
@@ -1,0 +1,19 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { UnicodeWhitespaceReader } from "../../src/lexer/UnicodeWhitespaceReader.js";
+
+test("UnicodeWhitespaceReader reads non-ASCII whitespace", () => {
+  const stream = new CharStream("\u00A0\u2003\u205Fabc");
+  const tok = UnicodeWhitespaceReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("WHITESPACE");
+  expect(tok.value).toBe("\u00A0\u2003\u205F");
+  expect(stream.current()).toBe("a");
+});
+
+test("UnicodeWhitespaceReader handles mixed whitespace", () => {
+  const stream = new CharStream(" \u2003\txyz");
+  const tok = UnicodeWhitespaceReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+  expect(tok.type).toBe("WHITESPACE");
+  expect(tok.value).toBe(" \u2003\t");
+  expect(stream.current()).toBe("x");
+});


### PR DESCRIPTION
## Summary
- add UnicodeWhitespaceReader to normalize Unicode whitespace
- test UnicodeWhitespaceReader with several whitespace characters
- wire up reader in LexerEngine
- document normalization rules
- update TODO checklist and task breakdown

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68540a87452c8331b784df195eed15ae