### PR TITLE
Refactor shared readers

### DIFF
--- a/src/lexer/BinaryReader.js
+++ b/src/lexer/BinaryReader.js
@@ -1,35 +1,11 @@
-// src/lexer/BinaryReader.js
+import { createRadixReader } from './RadixReader.js';
 
 /**
  * §4.4 BinaryReader
  * Parses binary integer literals like 0b1010 or 0B0101.
  */
-export function BinaryReader(stream, factory) {
-  const startPos = stream.getPosition();
+export const BinaryReader = createRadixReader(
+  ['b', 'B'],
+  ch => ch === '0' || ch === '1'
+);
 
-  // Must start with "0" followed by "b" or "B"
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'b' && prefix !== 'B') return null;
-
-  // Ensure there's at least one binary digit after the prefix
-  const next = stream.peek(2);
-  if (next === null || (next !== '0' && next !== '1')) {
-    // not a valid binary literal
-    return null;
-  }
-
-  // Consume "0" and "b"/"B"
-  let value = '0' + prefix;
-  stream.advance(); // consume '0'
-  stream.advance(); // consume 'b' or 'B'
-
-  // Consume all following binary digits
-  while (stream.current() === '0' || stream.current() === '1') {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
-}

--- a/src/lexer/HexReader.js
+++ b/src/lexer/HexReader.js
@@ -1,31 +1,7 @@
-export function HexReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'x' && prefix !== 'X') return null;
+import { createRadixReader, isHexDigit } from './RadixReader.js';
 
-  let idx = stream.index + 2;
-  const ch = stream.input[idx];
-  if (!ch || !isHexDigit(ch)) return null;
+export const HexReader = createRadixReader(
+  ['x', 'X'],
+  isHexDigit
+);
 
-  let value = '0' + prefix;
-  stream.advance();
-  stream.advance();
-
-  while (stream.current() !== null && isHexDigit(stream.current())) {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
-}
-
-function isHexDigit(ch) {
-  return (
-    ch !== null &&
-    ((ch >= '0' && ch <= '9') ||
-      (ch >= 'a' && ch <= 'f') ||
-      (ch >= 'A' && ch <= 'F'))
-  );
-}

--- a/src/lexer/OctalReader.js
+++ b/src/lexer/OctalReader.js
@@ -1,22 +1,7 @@
-export function OctalReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'o' && prefix !== 'O') return null;
+import { createRadixReader } from './RadixReader.js';
 
-  let idx = stream.index + 2;
-  const ch = stream.input[idx];
-  if (ch === undefined || ch < '0' || ch > '7') return null;
+export const OctalReader = createRadixReader(
+  ['o', 'O'],
+  ch => ch >= '0' && ch <= '7'
+);
 
-  let value = '0' + prefix;
-  stream.advance();
-  stream.advance();
-
-  while (stream.current() !== null && stream.current() >= '0' && stream.current() <= '7') {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
-}

--- a/src/lexer/RadixReader.js
+++ b/src/lexer/RadixReader.js
@@ -1,0 +1,31 @@
+export function createRadixReader(prefixChars, isDigit) {
+  return function(stream, factory) {
+    const startPos = stream.getPosition();
+    if (stream.current() !== '0') return null;
+    const prefix = stream.peek();
+    if (!prefixChars.includes(prefix)) return null;
+    const next = stream.peek(2);
+    if (next === null || !isDigit(next)) return null;
+
+    let value = '0' + prefix;
+    stream.advance();
+    stream.advance();
+
+    while (stream.current() !== null && isDigit(stream.current())) {
+      value += stream.current();
+      stream.advance();
+    }
+
+    const endPos = stream.getPosition();
+    return factory('NUMBER', value, startPos, endPos);
+  };
+}
+
+export function isHexDigit(ch) {
+  return (
+    ch !== null &&
+    ((ch >= '0' && ch <= '9') ||
+      (ch >= 'a' && ch <= 'f') ||
+      (ch >= 'A' && ch <= 'F'))
+  );
+}

--- a/src/plugins/DecoratorPlugin.js
+++ b/src/plugins/DecoratorPlugin.js
@@ -1,14 +1,4 @@
-export function TSDecoratorReader(stream, factory) {
-  const start = stream.getPosition();
-  if (stream.current() !== '@') return null;
-  let val = '@';
-  stream.advance();
-  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
-    val += stream.current();
-    stream.advance();
-  }
-  return factory('DECORATOR', val, start, stream.getPosition());
-}
+import { TSDecoratorReader } from './common/TSDecoratorReader.js';
 
 export const DecoratorPlugin = {
   modes: { default: [TSDecoratorReader] },

--- a/src/plugins/common/TSDecoratorReader.js
+++ b/src/plugins/common/TSDecoratorReader.js
@@ -1,0 +1,11 @@
+export function TSDecoratorReader(stream, factory) {
+  const start = stream.getPosition();
+  if (stream.current() !== '@') return null;
+  let value = '@';
+  stream.advance();
+  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+  return factory('DECORATOR', value, start, stream.getPosition());
+}

--- a/src/plugins/typescript/TypeScriptPlugin.js
+++ b/src/plugins/typescript/TypeScriptPlugin.js
@@ -1,14 +1,4 @@
-export function TSDecoratorReader(stream, factory) {
-  const start = stream.getPosition();
-  if (stream.current() !== '@') return null;
-  let value = '@';
-  stream.advance();
-  while (stream.current() && /[A-Za-z0-9_$]/.test(stream.current())) {
-    value += stream.current();
-    stream.advance();
-  }
-  return factory('DECORATOR', value, start, stream.getPosition());
-}
+import { TSDecoratorReader } from '../common/TSDecoratorReader.js';
 
 export function TSTypeAnnotationReader(stream, factory) {
   const start = stream.getPosition();


### PR DESCRIPTION
## Summary
- reuse TSDecoratorReader across plugins
- introduce generic RadixReader and use for binary, octal and hex literals

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68542ff3d7a48331917b7bc89fbf5137