### PR TITLE
Refactor shared helpers

### DIFF
--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -2,6 +2,7 @@ import { CharStream } from '../lexer/CharStream.js';
 import { LexerEngine } from '../lexer/LexerEngine.js';
 import { LexerError } from '../lexer/LexerError.js';
 import { Token } from '../lexer/Token.js';
+import { saveState, restoreState } from './stateUtils.js';
 
 /**
  * BufferedIncrementalLexer buffers incomplete tokens across feed() calls.
@@ -14,6 +15,7 @@ export class BufferedIncrementalLexer {
     this.stream = new CharStream('');
     this.engine = new LexerEngine(this.stream, { errorRecovery });
     this.trivia = [];
+    this._deps = { CharStream, LexerEngine, Token };
   }
 
   /**
@@ -74,19 +76,7 @@ export class BufferedIncrementalLexer {
    * @returns {object}
    */
   saveState() {
-    return {
-      input: this.stream.input,
-      position: this.stream.getPosition(),
-      tokens: this.tokens.map(t => t.toJSON()),
-      trivia: this.trivia.map(t => t.toJSON()),
-      engine: {
-        stateStack: [...this.engine.stateStack],
-        buffer: this.engine.buffer.map(t => t.toJSON()),
-        disableJsx: this.engine.disableJsx,
-        lastToken: this.engine.lastToken ? this.engine.lastToken.toJSON() : null,
-        errorRecovery: this.engine.errorRecovery
-      }
-    };
+    return saveState(this, true);
   }
 
   /**
@@ -94,27 +84,6 @@ export class BufferedIncrementalLexer {
    * @param {object} state
    */
   restoreState(state) {
-    this.stream = new CharStream(state.input);
-    this.stream.setPosition(state.position);
-    this.engine = new LexerEngine(this.stream, { errorRecovery: state.engine.errorRecovery });
-    this.engine.stateStack = [...state.engine.stateStack];
-    this.engine.buffer = state.engine.buffer.map(
-      t => new Token(t.type, t.value, t.start, t.end)
-    );
-    this.engine.disableJsx = state.engine.disableJsx;
-    this.engine.lastToken = state.engine.lastToken
-      ? new Token(
-          state.engine.lastToken.type,
-          state.engine.lastToken.value,
-          state.engine.lastToken.start,
-          state.engine.lastToken.end
-        )
-      : null;
-    this.tokens = state.tokens.map(
-      t => new Token(t.type, t.value, t.start, t.end)
-    );
-    this.trivia = state.trivia.map(
-      t => new Token(t.type, t.value, t.start, t.end)
-    );
+    restoreState(this, state, true);
   }
 }

--- a/src/integration/stateUtils.js
+++ b/src/integration/stateUtils.js
@@ -1,0 +1,41 @@
+export function serializeEngine(engine) {
+  return {
+    stateStack: [...engine.stateStack],
+    buffer: engine.buffer.map(t => t.toJSON()),
+    disableJsx: engine.disableJsx,
+    lastToken: engine.lastToken ? engine.lastToken.toJSON() : null,
+    errorRecovery: engine.errorRecovery
+  };
+}
+
+export function deserializeEngine(engine, data, Token) {
+  engine.stateStack = [...data.stateStack];
+  engine.buffer = data.buffer.map(t => new Token(t.type, t.value, t.start, t.end));
+  engine.disableJsx = data.disableJsx;
+  engine.lastToken = data.lastToken
+    ? new Token(data.lastToken.type, data.lastToken.value, data.lastToken.start, data.lastToken.end)
+    : null;
+  engine.errorRecovery = data.errorRecovery;
+}
+
+export function saveState(instance, includeTrivia = false) {
+  return {
+    input: instance.stream.input,
+    position: instance.stream.getPosition(),
+    tokens: instance.tokens.map(t => t.toJSON()),
+    ...(includeTrivia ? { trivia: instance.trivia.map(t => t.toJSON()) } : {}),
+    engine: serializeEngine(instance.engine)
+  };
+}
+
+export function restoreState(instance, state, includeTrivia = false) {
+  const { CharStream, LexerEngine, Token } = instance._deps;
+  instance.stream = new CharStream(state.input);
+  instance.stream.setPosition(state.position);
+  instance.engine = new LexerEngine(instance.stream, { errorRecovery: state.engine.errorRecovery });
+  deserializeEngine(instance.engine, state.engine, Token);
+  instance.tokens = state.tokens.map(t => new Token(t.type, t.value, t.start, t.end));
+  if (includeTrivia) {
+    instance.trivia = state.trivia.map(t => new Token(t.type, t.value, t.start, t.end));
+  }
+}

--- a/src/lexer/BigIntReader.js
+++ b/src/lexer/BigIntReader.js
@@ -1,3 +1,5 @@
+import { readDigitsWithUnderscores } from './utils.js';
+
 export function BigIntReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
@@ -10,26 +12,10 @@ export function BigIntReader(stream, factory) {
   }
   if (stream.input[idx] !== 'n') return null;
 
-  let value = '';
-  let underscoreSeen = false;
-  let lastUnderscore = false;
-
-  while (ch !== null && (ch >= '0' && ch <= '9' || ch === '_')) {
-    if (ch === '_') {
-      if (lastUnderscore) {
-        stream.setPosition(startPos);
-        return null;
-      }
-      underscoreSeen = true;
-      lastUnderscore = true;
-    } else {
-      lastUnderscore = false;
-    }
-
-    value += ch;
-    stream.advance();
-    ch = stream.current();
-  }
+  const result = readDigitsWithUnderscores(stream, startPos);
+  if (!result) return null;
+  let { value, underscoreSeen, lastUnderscore } = result;
+  ch = stream.current();
 
   if (lastUnderscore) {
     stream.setPosition(startPos);

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -1,31 +1,16 @@
+import { readDigitsWithUnderscores } from './utils.js';
+
 export function NumericSeparatorReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
   if (ch === null || ch < '0' || ch > '9') return null;
 
-  let value = '';
-  let underscoreSeen = false;
-  let lastUnderscore = false;
-
-  while (ch !== null && (ch >= '0' && ch <= '9' || ch === '_')) {
-    if (ch === '_') {
-      if (lastUnderscore) {
-        stream.index = startPos.index;
-        return null;
-      }
-      underscoreSeen = true;
-      lastUnderscore = true;
-    } else {
-      lastUnderscore = false;
-    }
-
-    value += ch;
-    stream.advance();
-    ch = stream.current();
-  }
+  const result = readDigitsWithUnderscores(stream, startPos);
+  if (!result) return null;
+  const { value, underscoreSeen, lastUnderscore } = result;
 
   if (!underscoreSeen || lastUnderscore) {
-    stream.index = startPos.index;
+    stream.setPosition(startPos);
     return null;
   }
 

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -1,0 +1,22 @@
+export function readDigitsWithUnderscores(stream, startPos) {
+  let value = '';
+  let underscoreSeen = false;
+  let lastUnderscore = false;
+  let ch = stream.current();
+  while (ch !== null && ((ch >= '0' && ch <= '9') || ch === '_')) {
+    if (ch === '_') {
+      if (lastUnderscore) {
+        stream.setPosition(startPos);
+        return null;
+      }
+      underscoreSeen = true;
+      lastUnderscore = true;
+    } else {
+      lastUnderscore = false;
+    }
+    value += ch;
+    stream.advance();
+    ch = stream.current();
+  }
+  return { value, underscoreSeen, lastUnderscore };
+}


### PR DESCRIPTION
## Summary
- factor out lexer state serialization logic
- add utility to parse digits with underscores
- use utilities in IncrementalLexer, BufferedIncrementalLexer, BigIntReader and NumericSeparatorReader

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685431525efc8331bdcd966a19574c06