### PR TITLE
Add repo info utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Use the convenience script to run linting, tests, and benchmarks in one go:
 ```bash
 npm run workflow
 ```
+
+### Repository Info
+Print an overview of available scripts and open tasks:
+
+```bash
+npm run repo-info
+```
 ## Code of Conduct
 
 Please read `CODE_OF_CONDUCT.md` to understand expectations for participation.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:extension": "npm --prefix extension install && npm --prefix extension run build",
     "publish:extension": "npm --prefix extension install && npm --prefix extension run publish",
     "workflow": "bash scripts/run-workflow.sh",
-    "next-task": "node scripts/next-task.cjs"
+    "next-task": "node scripts/next-task.cjs",
+    "repo-info": "node scripts/repo-info.cjs"
   },
   "keywords": [
     "lexer",

--- a/scripts/next-task.cjs
+++ b/scripts/next-task.cjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // scripts/next-task.cjs
 // Print the highest priority unchecked task from docs/TODO_CHECKLIST.md
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
 const checklistPath = path.join('docs', 'TODO_CHECKLIST.md');
 const content = fs.readFileSync(checklistPath, 'utf8');

--- a/scripts/repo-info.cjs
+++ b/scripts/repo-info.cjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// scripts/repo-info.cjs
+// Summarize key repo information for new agents
+const fs = require('fs');
+const path = require('path');
+
+function heading(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+heading('Node Version');
+console.log(process.version);
+
+heading('NPM Scripts');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+for (const [name, cmd] of Object.entries(pkg.scripts || {})) {
+  console.log(`${name}: ${cmd}`);
+}
+
+heading('Open Tasks');
+const todoPath = path.join('docs', 'TODO_CHECKLIST.md');
+if (fs.existsSync(todoPath)) {
+  const text = fs.readFileSync(todoPath, 'utf8');
+  const tasks = text.match(/^\- \[ \] .+$/gm) || [];
+  if (tasks.length) {
+    tasks.forEach(t => console.log(t.replace('- [ ] ', '')));
+  } else {
+    console.log('No open tasks!');
+  }
+} else {
+  console.log('No TODO_CHECKLIST.md found');
+}
+
+heading('Next Task');
+const nextTaskScript = path.join('scripts', 'next-task.cjs');
+if (fs.existsSync(nextTaskScript)) {
+  const { spawnSync } = require('child_process');
+  const res = spawnSync('node', [nextTaskScript]);
+  process.stdout.write(res.stdout);
+} else {
+  console.log('next-task.cjs not found');
+}


### PR DESCRIPTION
## Summary
- add `repo-info.cjs` to print node version, npm scripts and TODO list
- expose it via npm script
- fix commonjs syntax in `next-task.cjs`
- document repo info command in README

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `node scripts/repo-info.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68543aef3e2c83319edac59e970a04ba