### PR TITLE
Improve grammar lookups with sets

### DIFF
--- a/src/grammar/JavaScriptGrammar.js
+++ b/src/grammar/JavaScriptGrammar.js
@@ -1,17 +1,26 @@
 // JavaScript grammar definitions
+const keywords = [
+  "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
+  "do", "else", "export", "extends", "finally", "for", "function", "if", "import",
+  "in", "instanceof", "let",
+  "new", "return", "super", "switch", "this", "throw", "try", "typeof", "var", "void",
+  "while", "with", "yield"
+];
+
+const operators = [
+  "?.", "??", "??=", "|>",
+  "+", "-", "*", "/", "%", "++", "--", "=", "+=", "-=", "*=", "**", "/=", "%=", "**=", "==", "===", "!=", "!==",
+  "&&=", "||=",
+  ">", "<", ">=", "<=", "&&", "||", "!", "?", "...", "=>"
+];
+
+const punctuation = ["{", "}", "(", ")", "[", "]", ".", ";", ","];
+
 export const JavaScriptGrammar = {
-  keywords: [
-    "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
-    "do", "else", "export", "extends", "finally", "for", "function", "if", "import",
-    "in", "instanceof", "let",    // ← added "let" here
-    "new", "return", "super", "switch", "this", "throw", "try", "typeof", "var", "void",
-    "while", "with", "yield"
-  ],
-  operators: [
-    "?.", "??", "??=", "|>",
-    "+", "-", "*", "/", "%", "++", "--", "=", "+=", "-=", "*=", "**", "/=", "%=", "**=", "==", "===", "!=", "!==",
-    "&&=", "||=",
-    ">", "<", ">=", "<=", "&&", "||", "!", "?", "...", "=>"
-  ],
-  punctuation: ["{","}","(",")","[","]",".",";",","]
+  keywords,
+  keywordSet: new Set(keywords),
+  operators,
+  sortedOperators: operators.slice().sort((a, b) => b.length - a.length),
+  punctuation,
+  punctuationSet: new Set(punctuation)
 };

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -134,7 +134,7 @@ export class LexerEngine {
           // 3. Promote identifiers matching keywords
           if (
             token.type === 'IDENTIFIER' &&
-            JavaScriptGrammar.keywords.includes(token.value)
+            JavaScriptGrammar.keywordSet.has(token.value)
           ) {
             token.type = 'KEYWORD';
           }

--- a/src/lexer/OperatorReader.js
+++ b/src/lexer/OperatorReader.js
@@ -1,9 +1,7 @@
 // §4.3 OperatorReader
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
 
-const ops = JavaScriptGrammar.operators
-  .slice()
-  .sort((a, b) => b.length - a.length);
+const ops = JavaScriptGrammar.sortedOperators;
 
 export function OperatorReader(stream, factory) {
   const startPos = stream.getPosition();

--- a/src/lexer/PunctuationReader.js
+++ b/src/lexer/PunctuationReader.js
@@ -4,7 +4,7 @@ import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
 export function PunctuationReader(stream, factory) {
   const startPos = stream.getPosition();
   const ch = stream.current();
-  if (JavaScriptGrammar.punctuation.includes(ch)) {
+  if (JavaScriptGrammar.punctuationSet.has(ch)) {
     stream.advance();
     const endPos = stream.getPosition();
     return factory('PUNCTUATION', ch, startPos, endPos);

--- a/tests/fixtures/lexer_engine.js
+++ b/tests/fixtures/lexer_engine.js
@@ -68,7 +68,7 @@ export class LexerEngine {
           // 3. Promote identifiers that match keywords
           if (
             token.type === 'IDENTIFIER' &&
-            JavaScriptGrammar.keywords.includes(token.value)
+            JavaScriptGrammar.keywordSet.has(token.value)
           ) {
             token.type = 'KEYWORD';
           }


### PR DESCRIPTION
## Summary
- add sets to JavaScript grammar for faster lookups
- use `keywordSet` and `punctuationSet` in lexer
- expose sorted operators list from grammar

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854406217c08331b39767b439f1bdbb