### PR TITLE
Add ImportMeta reader and plugin

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -88,3 +88,14 @@ import { FlowTypePlugin } from './src/plugins/flow/FlowTypePlugin.js';
 
 registerPlugin(FlowTypePlugin);
 ```
+
+## ImportMeta Plugin
+
+The `ImportMetaPlugin` adds readers for the `import.meta` meta property and
+simple dynamic `import()` calls.
+
+```javascript
+import { ImportMetaPlugin } from './src/plugins/importmeta/ImportMetaPlugin.js';
+
+registerPlugin(ImportMetaPlugin);
+```

--- a/src/lexer/ImportCallReader.js
+++ b/src/lexer/ImportCallReader.js
@@ -1,0 +1,22 @@
+export function ImportCallReader(stream, factory) {
+  const startPos = stream.getPosition();
+  if (!stream.input.startsWith('import(', startPos.index)) return null;
+
+  const saved = stream.getPosition();
+  for (const ch of 'import') {
+    if (stream.current() !== ch) {
+      stream.setPosition(saved);
+      return null;
+    }
+    stream.advance();
+  }
+
+  // confirm '(' but don't consume
+  if (stream.current() !== '(') {
+    stream.setPosition(saved);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('IMPORT_CALL', 'import', startPos, endPos);
+}

--- a/src/lexer/ImportMetaReader.js
+++ b/src/lexer/ImportMetaReader.js
@@ -1,0 +1,23 @@
+export function ImportMetaReader(stream, factory) {
+  const startPos = stream.getPosition();
+  const seq = 'import.meta';
+  if (!stream.input.startsWith(seq, startPos.index)) return null;
+
+  const saved = stream.getPosition();
+  for (const ch of seq) {
+    if (stream.current() !== ch) {
+      stream.setPosition(saved);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next && /[A-Za-z0-9_$]/.test(next)) {
+    stream.setPosition(saved);
+    return null;
+  }
+
+  const endPos = stream.getPosition();
+  return factory('IMPORT_META', seq, startPos, endPos);
+}

--- a/src/plugins/importmeta/ImportMetaPlugin.js
+++ b/src/plugins/importmeta/ImportMetaPlugin.js
@@ -1,0 +1,12 @@
+import { ImportMetaReader } from '../../lexer/ImportMetaReader.js';
+import { ImportCallReader } from '../../lexer/ImportCallReader.js';
+
+export const ImportMetaPlugin = {
+  modes: { default: [ImportMetaReader, ImportCallReader] },
+  init(engine) {
+    const orig = engine.modes.default.filter(r =>
+      r !== ImportMetaReader && r !== ImportCallReader
+    );
+    engine.modes.default = [ImportMetaReader, ImportCallReader, ...orig];
+  }
+};

--- a/tests/importMetaPlugin.test.js
+++ b/tests/importMetaPlugin.test.js
@@ -1,0 +1,24 @@
+import { CharStream } from '../src/lexer/CharStream.js';
+import { LexerEngine } from '../src/lexer/LexerEngine.js';
+import { registerPlugin, clearPlugins } from '../index.js';
+import { ImportMetaPlugin } from '../src/plugins/importmeta/ImportMetaPlugin.js';
+
+afterEach(() => {
+  clearPlugins();
+});
+
+test('ImportMetaPlugin tokenizes import.meta', () => {
+  registerPlugin(ImportMetaPlugin);
+  const engine = new LexerEngine(new CharStream('import.meta.url;'));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('IMPORT_META');
+  expect(tok.value).toBe('import.meta');
+});
+
+test('ImportMetaPlugin tokenizes dynamic import', () => {
+  registerPlugin(ImportMetaPlugin);
+  const engine = new LexerEngine(new CharStream("import('./mod.js')"));
+  const tok = engine.nextToken();
+  expect(tok.type).toBe('IMPORT_CALL');
+  expect(tok.value).toBe('import');
+});

--- a/tests/readers/ImportMetaReader.test.js
+++ b/tests/readers/ImportMetaReader.test.js
@@ -1,0 +1,18 @@
+import { CharStream } from "../../src/lexer/CharStream.js";
+import { Token } from "../../src/lexer/Token.js";
+import { ImportMetaReader } from "../../src/lexer/ImportMetaReader.js";
+
+ test("ImportMetaReader reads import.meta", () => {
+   const stream = new CharStream("import.meta");
+   const tok = ImportMetaReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok.type).toBe("IMPORT_META");
+   expect(tok.value).toBe("import.meta");
+ });
+
+ test("ImportMetaReader returns null when sequence mismatched", () => {
+   const stream = new CharStream("import.met");
+   const pos = stream.getPosition();
+   const tok = ImportMetaReader(stream, (t,v,s,e) => new Token(t,v,s,e));
+   expect(tok).toBeNull();
+   expect(stream.getPosition()).toEqual(pos);
+ });


### PR DESCRIPTION
## Summary
- support `import.meta` and dynamic `import()` tokens
- expose new `ImportMetaPlugin` via plugin API
- document ImportMeta plugin
- test coverage for new readers and plugin

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68544408d1f48331a7e4b74a8dbfbab0