### PR TITLE
Enhance token metadata with range and source URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,11 @@ import { fileURLToPath } from "url";
  * @param root0
  * @param root0.verbose
  */
-export function tokenize(code, { verbose = false, errorRecovery = false } = {}) {
-  const stream = new CharStream(code);
+export function tokenize(
+  code,
+  { verbose = false, errorRecovery = false, sourceURL = null } = {}
+) {
+  const stream = new CharStream(code, { sourceURL });
   const lexer = new LexerEngine(stream, { errorRecovery });
   const tokens = [];
   for (const tok of tokenIterator(lexer)) {

--- a/src/integration/BufferedIncrementalLexer.js
+++ b/src/integration/BufferedIncrementalLexer.js
@@ -9,10 +9,10 @@ import { saveState, restoreState } from './stateUtils.js';
  * It avoids throwing when a chunk ends in the middle of a token.
  */
 export class BufferedIncrementalLexer {
-  constructor({ onToken, errorRecovery = false } = {}) {
+  constructor({ onToken, errorRecovery = false, sourceURL = null } = {}) {
     this.onToken = onToken || (() => {});
     this.tokens = [];
-    this.stream = new CharStream('');
+    this.stream = new CharStream('', { sourceURL });
     this.engine = new LexerEngine(this.stream, { errorRecovery });
     this.trivia = [];
     this._deps = { CharStream, LexerEngine, Token };

--- a/src/integration/IncrementalLexer.js
+++ b/src/integration/IncrementalLexer.js
@@ -8,10 +8,10 @@ import { tokenIterator } from './tokenUtils.js';
  * IncrementalLexer allows feeding code chunks and emits tokens as they are produced.
  */
 export class IncrementalLexer {
-  constructor({ onToken, errorRecovery = false } = {}) {
+  constructor({ onToken, errorRecovery = false, sourceURL = null } = {}) {
     this.onToken = onToken || (() => {});
     this.tokens = [];
-    this.stream = new CharStream('');
+    this.stream = new CharStream('', { sourceURL });
     this.engine = new LexerEngine(this.stream, { errorRecovery });
     // dependencies for state helpers
     this._deps = { CharStream, LexerEngine, Token };

--- a/src/lexer/CharStream.js
+++ b/src/lexer/CharStream.js
@@ -2,12 +2,13 @@
  * Provides character level access with position tracking for the lexer.
  */
 export class CharStream {
-  constructor(input) {
+  constructor(input, { sourceURL = null } = {}) {
     this.input = input;
     this.length = input.length;
     this.index = 0;
     this.line = 1;
     this.column = 0;
+    this.sourceURL = sourceURL;
   }
 
   append(chunk) {
@@ -39,7 +40,12 @@ export class CharStream {
   }
 
   getPosition() {
-    return { line: this.line, column: this.column, index: this.index };
+    return {
+      line: this.line,
+      column: this.column,
+      index: this.index,
+      sourceURL: this.sourceURL
+    };
   }
 
   setPosition(pos) {

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -79,7 +79,8 @@ export class LexerEngine {
    */
   _readFromStream() {
     const { stream } = this;
-    const factory = (type, value, start, end) => new Token(type, value, start, end);
+    const factory = (type, value, start, end) =>
+      new Token(type, value, start, end, stream.sourceURL);
 
     while (!stream.eof()) {
       // 0. Emit comments

--- a/src/lexer/Token.js
+++ b/src/lexer/Token.js
@@ -2,14 +2,24 @@
  * Represents a single lexical token produced by the lexer.
  */
 export class Token {
-  constructor(type, value, start, end) {
+  constructor(type, value, start, end, sourceURL = start.sourceURL || null) {
     this.type = type;
     this.value = value;
     this.start = start;
     this.end = end;
+    this.range = [start.index, end.index];
+    this.sourceURL = sourceURL;
     this.trivia = { leading: [], trailing: [] };
   }
   toJSON() {
-    return { type: this.type, value: this.value, start: this.start, end: this.end };
+    const obj = {
+      type: this.type,
+      value: this.value,
+      start: this.start,
+      end: this.end,
+      range: this.range
+    };
+    if (this.sourceURL) obj.sourceURL = this.sourceURL;
+    return obj;
   }
 }

--- a/tests/readers/CharStream.test.js
+++ b/tests/readers/CharStream.test.js
@@ -3,23 +3,23 @@ import { CharStream } from "../../src/lexer/CharStream.js";
 test("CharStream advance updates line and column across newlines", () => {
   const stream = new CharStream("a\nb\n");
   // start position before any advance
-  expect(stream.getPosition()).toEqual({ line: 1, column: 0, index: 0 });
+  expect(stream.getPosition()).toEqual({ line: 1, column: 0, index: 0, sourceURL: null });
 
   // advance over 'a'
   stream.advance();
-  expect(stream.getPosition()).toEqual({ line: 1, column: 1, index: 1 });
+  expect(stream.getPosition()).toEqual({ line: 1, column: 1, index: 1, sourceURL: null });
 
   // advance over '\n' should increment line and reset column
   stream.advance();
-  expect(stream.getPosition()).toEqual({ line: 2, column: 0, index: 2 });
+  expect(stream.getPosition()).toEqual({ line: 2, column: 0, index: 2, sourceURL: null });
 
   // advance over 'b'
   stream.advance();
-  expect(stream.getPosition()).toEqual({ line: 2, column: 1, index: 3 });
+  expect(stream.getPosition()).toEqual({ line: 2, column: 1, index: 3, sourceURL: null });
 
   // advance over final '\n'
   stream.advance();
-  expect(stream.getPosition()).toEqual({ line: 3, column: 0, index: 4 });
+  expect(stream.getPosition()).toEqual({ line: 3, column: 0, index: 4, sourceURL: null });
 });
 
 test("CharStream setPosition restores previous position", () => {
@@ -54,11 +54,11 @@ test("CharStream current/peek/eof handling at bounds", () => {
 test("CharStream handles CRLF newlines", () => {
   const stream = new CharStream("a\r\nb");
   stream.advance(); // 'a'
-  expect(stream.getPosition()).toEqual({ line: 1, column: 1, index: 1 });
+  expect(stream.getPosition()).toEqual({ line: 1, column: 1, index: 1, sourceURL: null });
   stream.advance(); // '\r'
-  expect(stream.getPosition()).toEqual({ line: 1, column: 2, index: 2 });
+  expect(stream.getPosition()).toEqual({ line: 1, column: 2, index: 2, sourceURL: null });
   stream.advance(); // '\n'
-  expect(stream.getPosition()).toEqual({ line: 2, column: 0, index: 3 });
+  expect(stream.getPosition()).toEqual({ line: 2, column: 0, index: 3, sourceURL: null });
   stream.advance(); // 'b'
-  expect(stream.getPosition()).toEqual({ line: 2, column: 1, index: 4 });
+  expect(stream.getPosition()).toEqual({ line: 2, column: 1, index: 4, sourceURL: null });
 });

--- a/tests/token.test.js
+++ b/tests/token.test.js
@@ -4,15 +4,24 @@ test("Token.toJSON produces plain object", () => {
   const tok = new Token(
     "NUMBER",
     "1",
-    { line: 1, column: 0 },
-    { line: 1, column: 1 }
+    { line: 1, column: 0, index: 0, sourceURL: "test.js" },
+    { line: 1, column: 1, index: 1, sourceURL: "test.js" }
   );
   const expected = {
     type: "NUMBER",
     value: "1",
-    start: { line: 1, column: 0 },
-    end: { line: 1, column: 1 }
+    start: { line: 1, column: 0, index: 0, sourceURL: "test.js" },
+    end: { line: 1, column: 1, index: 1, sourceURL: "test.js" },
+    range: [0, 1],
+    sourceURL: "test.js"
   };
   expect(tok.toJSON()).toEqual(expected);
   expect(JSON.parse(JSON.stringify(tok))).toEqual(expected);
+});
+
+import { tokenize } from '../index.js';
+
+test('tokenize includes sourceURL in tokens', () => {
+  const toks = tokenize('let a = 1;', { sourceURL: 'foo.js' });
+  expect(toks[0].sourceURL).toBe('foo.js');
 });


### PR DESCRIPTION
## Summary
- track a `sourceURL` in `CharStream`
- capture source info and byte range in `Token`
- pass source through lexers and engine
- persist `sourceURL` in save/restore state helpers
- expose metadata via `tokenize` API
- update tests for new structure

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6854464df45c8331bfac9ae0c745deae