### PR TITLE
Introduce plugin manager for cleaner extensibility

### DIFF
--- a/docs/LEXER_SPEC.md
+++ b/docs/LEXER_SPEC.md
@@ -122,13 +122,13 @@ stream.on('data', token => {
 
 ## 12. Plugin API <a name="plugin"></a>
 Plugins extend the lexer with additional readers. Register them via
-`LexerEngine.registerPlugin` before creating a lexer instance.
+the exported `registerPlugin` helper before creating a lexer instance.
 
 ```javascript
-import { LexerEngine } from './src/lexer/LexerEngine.js';
+import { registerPlugin } from './index.js';
 import { HashPlugin } from './hash-plugin.js';
 
-LexerEngine.registerPlugin(HashPlugin);
+registerPlugin(HashPlugin);
 ```
 
 Plugins may provide readers for any mode using a `modes` map and an optional

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { CharStream } from "./src/lexer/CharStream.js";
 import { LexerEngine } from "./src/lexer/LexerEngine.js";
+import { registerPlugin, clearPlugins } from "./src/plugins/index.js";
 import { IncrementalLexer } from "./src/integration/IncrementalLexer.js";
 import { BufferedIncrementalLexer } from "./src/integration/BufferedIncrementalLexer.js";
 import { createTokenStream } from "./src/integration/TokenStream.js";
@@ -27,9 +28,7 @@ export function tokenize(
   return tokens;
 }
 
-export const registerPlugin = LexerEngine.registerPlugin.bind(LexerEngine);
-export const clearPlugins = LexerEngine.clearPlugins.bind(LexerEngine);
-export { IncrementalLexer, BufferedIncrementalLexer, createTokenStream };
+export { registerPlugin, clearPlugins, IncrementalLexer, BufferedIncrementalLexer, createTokenStream };
 
 // Only run CLI when invoked directly
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -10,21 +10,12 @@ import { baseReaders } from './defaultReaders.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
+import { pluginManager } from '../plugins/index.js';
 
 /**
  * LexerEngine orchestrates all token readers to produce a stream of Tokens.
  */
 export class LexerEngine {
-  static plugins = [];
-
-  static registerPlugin(plugin) {
-    this.plugins.push(plugin);
-  }
-
-  static clearPlugins() {
-    this.plugins = [];
-  }
-
   constructor(stream, { errorRecovery = false } = {}) {
     this.stream = stream;
     this.errorRecovery = errorRecovery;
@@ -44,17 +35,7 @@ export class LexerEngine {
     };
 
     // Apply registered plugins
-    for (const plugin of LexerEngine.plugins) {
-      if (plugin.modes) {
-        for (const [mode, readers] of Object.entries(plugin.modes)) {
-          if (!this.modes[mode]) this.modes[mode] = [];
-          this.modes[mode].push(...readers);
-        }
-      }
-      if (typeof plugin.init === 'function') {
-        plugin.init(this);
-      }
-    }
+    pluginManager.apply(this);
 
     this.lastToken = null;
   }

--- a/src/plugins/PluginManager.js
+++ b/src/plugins/PluginManager.js
@@ -1,0 +1,27 @@
+export class PluginManager {
+  constructor() {
+    this.plugins = [];
+  }
+
+  register(plugin) {
+    this.plugins.push(plugin);
+  }
+
+  clear() {
+    this.plugins = [];
+  }
+
+  apply(engine) {
+    for (const plugin of this.plugins) {
+      if (plugin.modes) {
+        for (const [mode, readers] of Object.entries(plugin.modes)) {
+          if (!engine.modes[mode]) engine.modes[mode] = [];
+          engine.modes[mode].push(...readers);
+        }
+      }
+      if (typeof plugin.init === 'function') {
+        plugin.init(engine);
+      }
+    }
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,11 @@
+import { PluginManager } from './PluginManager.js';
+
+export const pluginManager = new PluginManager();
+
+export function registerPlugin(plugin) {
+  pluginManager.register(plugin);
+}
+
+export function clearPlugins() {
+  pluginManager.clear();
+}


### PR DESCRIPTION
## Summary
- centralize plugin handling via new `PluginManager`
- use the manager inside `LexerEngine`
- re-export plugin utilities from new module
- update plugin docs

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6854659608048331b650cec2be4bb150