### PR TITLE
[agent] refactor: unify prefixed number readers

### DIFF
--- a/scripts/post-context.js
+++ b/scripts/post-context.js
@@ -1,6 +1,5 @@
+#!/usr/bin/env node
 // .github/scripts/post-context.js
-
-!/usr/bin/env node
 /**
  * post-context.js
  *

--- a/src/lexer/BinaryReader.js
+++ b/src/lexer/BinaryReader.js
@@ -4,32 +4,13 @@
  * §4.4 BinaryReader
  * Parses binary integer literals like 0b1010 or 0B0101.
  */
+import { readPrefixedNumber } from './helpers/readPrefixedNumber.js';
+
 export function BinaryReader(stream, factory) {
-  const startPos = stream.getPosition();
-
-  // Must start with "0" followed by "b" or "B"
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'b' && prefix !== 'B') return null;
-
-  // Ensure there's at least one binary digit after the prefix
-  const next = stream.peek(2);
-  if (next === null || (next !== '0' && next !== '1')) {
-    // not a valid binary literal
-    return null;
-  }
-
-  // Consume "0" and "b"/"B"
-  let value = '0' + prefix;
-  stream.advance(); // consume '0'
-  stream.advance(); // consume 'b' or 'B'
-
-  // Consume all following binary digits
-  while (stream.current() === '0' || stream.current() === '1') {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
+  return readPrefixedNumber(
+    stream,
+    factory,
+    'bB',
+    ch => ch === '0' || ch === '1'
+  );
 }

--- a/src/lexer/HexReader.js
+++ b/src/lexer/HexReader.js
@@ -1,31 +1,14 @@
+import { readPrefixedNumber } from './helpers/readPrefixedNumber.js';
+
 export function HexReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'x' && prefix !== 'X') return null;
-
-  let idx = stream.index + 2;
-  const ch = stream.input[idx];
-  if (!ch || !isHexDigit(ch)) return null;
-
-  let value = '0' + prefix;
-  stream.advance();
-  stream.advance();
-
-  while (stream.current() !== null && isHexDigit(stream.current())) {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
-}
-
-function isHexDigit(ch) {
-  return (
-    ch !== null &&
-    ((ch >= '0' && ch <= '9') ||
-      (ch >= 'a' && ch <= 'f') ||
-      (ch >= 'A' && ch <= 'F'))
+  return readPrefixedNumber(
+    stream,
+    factory,
+    'xX',
+    ch =>
+      ch !== null &&
+      ((ch >= '0' && ch <= '9') ||
+        (ch >= 'a' && ch <= 'f') ||
+        (ch >= 'A' && ch <= 'F'))
   );
 }

--- a/src/lexer/OctalReader.js
+++ b/src/lexer/OctalReader.js
@@ -1,22 +1,10 @@
+import { readPrefixedNumber } from './helpers/readPrefixedNumber.js';
+
 export function OctalReader(stream, factory) {
-  const startPos = stream.getPosition();
-  if (stream.current() !== '0') return null;
-  const prefix = stream.peek();
-  if (prefix !== 'o' && prefix !== 'O') return null;
-
-  let idx = stream.index + 2;
-  const ch = stream.input[idx];
-  if (ch === undefined || ch < '0' || ch > '7') return null;
-
-  let value = '0' + prefix;
-  stream.advance();
-  stream.advance();
-
-  while (stream.current() !== null && stream.current() >= '0' && stream.current() <= '7') {
-    value += stream.current();
-    stream.advance();
-  }
-
-  const endPos = stream.getPosition();
-  return factory('NUMBER', value, startPos, endPos);
+  return readPrefixedNumber(
+    stream,
+    factory,
+    'oO',
+    ch => ch >= '0' && ch <= '7'
+  );
 }

--- a/src/lexer/helpers/readPrefixedNumber.js
+++ b/src/lexer/helpers/readPrefixedNumber.js
@@ -1,0 +1,20 @@
+export function readPrefixedNumber(stream, factory, prefixChars, isValidDigit) {
+  const startPos = stream.getPosition();
+  if (stream.current() !== '0') return null;
+  const prefix = stream.peek();
+  if (!prefix || !prefixChars.includes(prefix)) return null;
+  const firstDigit = stream.peek(2);
+  if (firstDigit === null || !isValidDigit(firstDigit)) return null;
+
+  let value = '0' + prefix;
+  stream.advance(); // consume '0'
+  stream.advance(); // consume prefix
+
+  while (stream.current() !== null && isValidDigit(stream.current())) {
+    value += stream.current();
+    stream.advance();
+  }
+
+  const endPos = stream.getPosition();
+  return factory('NUMBER', value, startPos, endPos);
+}


### PR DESCRIPTION
## Summary
- fix `post-context.js` shebang
- centralize prefixed number logic with `readPrefixedNumber`
- simplify `BinaryReader`, `HexReader`, and `OctalReader` using the helper

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `npm run check` *(fails: cannot find `.github/scripts/compare-benchmark.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68547c8d5d6c83318f0e1f42a0340549