### PR TITLE
[agent] docs: remove extraneous intro lines from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-**`README.md`**  
-(Inserted **Agent Workflow** before Code of Conduct and updated step 6.)  
-
 # experimental-js-lexer
 
 A modular, adaptive, experimental JavaScript lexer designed for autonomous development by OpenAI Codex agents.


### PR DESCRIPTION
## Summary
- remove outdated leading lines so README begins immediately with `# experimental-js-lexer`

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68548b60d8008331873a690221b14be0