### PR TITLE
[agent] docs: replace code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,13 +1,32 @@
-## Code of Conduct
+# Contributor Covenant Code of Conduct
 
-Please read `CODE_OF_CONDUCT.md` to understand expectations for participation.
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-## Changelog
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
-All notable changes are tracked in `CHANGELOG.md`.
+## Expected Behavior
+Examples of behavior that contributes to a positive environment for our community include:
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-## Benchmarks
+Examples of unacceptable behavior include:
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-Measure lexing throughput on the sample files in `tests/fixtures`:
+## Reporting
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at [INSERT EMAIL ADDRESS]. All complaints will be reviewed and investigated promptly and fairly.
 
-node tests/benchmarks/lexer.bench.js
+## Enforcement
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
## Summary
- replace `CODE_OF_CONDUCT.md` with the Contributor Covenant

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68548b63389883319e87740016d0745a