### PR TITLE
[agent] refactor digit utilities

### DIFF
--- a/src/lexer/BigIntReader.js
+++ b/src/lexer/BigIntReader.js
@@ -1,9 +1,9 @@
-import { readDigitsWithUnderscores } from './utils.js';
+import { readDigitsWithUnderscores, isDigit } from './utils.js';
 
 export function BigIntReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
-  if (ch === null || ch < '0' || ch > '9') return null;
+  if (!isDigit(ch)) return null;
 
   // verify there is a trailing 'n' so this is really a bigint
   let idx = stream.index;

--- a/src/lexer/DecimalLiteralReader.js
+++ b/src/lexer/DecimalLiteralReader.js
@@ -1,4 +1,4 @@
-import { readDigits } from './utils.js';
+import { readDigits, isDigit } from './utils.js';
 
 export function DecimalLiteralReader(stream, factory) {
   const startPos = stream.getPosition();
@@ -8,7 +8,7 @@ export function DecimalLiteralReader(stream, factory) {
   if (ch === '0' && (stream.peek() === 'd' || stream.peek() === 'D')) {
     // ensure digits after prefix
     const firstDigit = stream.peek(2);
-    if (firstDigit === null || firstDigit < '0' || firstDigit > '9') return null;
+    if (!isDigit(firstDigit)) return null;
 
     let value = '0' + stream.peek();
     stream.advance(); // 0
@@ -31,7 +31,7 @@ export function DecimalLiteralReader(stream, factory) {
   }
 
   // suffix form 123.45m or 123m
-  if (ch !== null && ch >= '0' && ch <= '9') {
+  if (isDigit(ch)) {
     let value = readDigits(stream);
     ch = stream.current();
     if (ch === '.') {

--- a/src/lexer/ExponentReader.js
+++ b/src/lexer/ExponentReader.js
@@ -1,8 +1,8 @@
-import { readDigits } from './utils.js';
+import { readDigits, isDigit } from './utils.js';
 
 export function ExponentReader(stream, factory) {
   const startPos = stream.getPosition();
-  if (stream.current() === null || stream.current() < '0' || stream.current() > '9') return null;
+  if (!isDigit(stream.current())) return null;
 
   let value = readDigits(stream);
   let ch = stream.current();

--- a/src/lexer/NumberReader.js
+++ b/src/lexer/NumberReader.js
@@ -1,8 +1,5 @@
 // §4.2 NumberReader
-import { readDigits } from './utils.js';
-function isDigit(ch) {
-  return ch !== null && ch >= '0' && ch <= '9';
-}
+import { readDigits, isDigit } from './utils.js';
 
 export function NumberReader(stream, factory) {
   const startPos = stream.getPosition();

--- a/src/lexer/NumericSeparatorReader.js
+++ b/src/lexer/NumericSeparatorReader.js
@@ -1,9 +1,9 @@
-import { readDigitsWithUnderscores } from './utils.js';
+import { readDigitsWithUnderscores, isDigit } from './utils.js';
 
 export function NumericSeparatorReader(stream, factory) {
   const startPos = stream.getPosition();
   let ch = stream.current();
-  if (ch === null || ch < '0' || ch > '9') return null;
+  if (!isDigit(ch)) return null;
 
   const result = readDigitsWithUnderscores(stream, startPos);
   if (!result) return null;

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -1,9 +1,13 @@
+export function isDigit(ch) {
+  return ch !== null && ch >= '0' && ch <= '9';
+}
+
 export function readDigitsWithUnderscores(stream, startPos) {
   let value = '';
   let underscoreSeen = false;
   let lastUnderscore = false;
   let ch = stream.current();
-  while (ch !== null && ((ch >= '0' && ch <= '9') || ch === '_')) {
+  while (ch !== null && (isDigit(ch) || ch === '_')) {
     if (ch === '_') {
       if (lastUnderscore) {
         stream.setPosition(startPos);
@@ -24,7 +28,7 @@ export function readDigitsWithUnderscores(stream, startPos) {
 export function readDigits(stream) {
   let value = '';
   let ch = stream.current();
-  while (ch !== null && ch >= '0' && ch <= '9') {
+  while (isDigit(ch)) {
     value += ch;
     stream.advance();
     ch = stream.current();


### PR DESCRIPTION
## Summary
- centralize digit check logic in `utils.js`
- refactor numeric readers to use the new helper

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854b5bf54b08331addc73c1cb51da8c