### PR TITLE
[agent] fix workflow: checkout repo for codegen job

### DIFF
--- a/.github/workflows/agent-workflow.yml
+++ b/.github/workflows/agent-workflow.yml
@@ -46,6 +46,9 @@ jobs:
       GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY:  ${{ github.repository }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Run automation
         run: node agentic-automation.js
 


### PR DESCRIPTION
## Summary
- ensure `codegen-agent` job checks out repository before running automation

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854b4f5ab0483319eba211c796735b7