### PR TITLE
[agent] feat(plugin): deduplicate type annotation readers

### DIFF
--- a/src/plugins/common/TypeAnnotationReader.js
+++ b/src/plugins/common/TypeAnnotationReader.js
@@ -1,0 +1,22 @@
+export function createTypeAnnotationReader({ allowQuestionMark = false } = {}) {
+  const pattern = allowQuestionMark
+    ? /[A-Za-z0-9_<>,\s?]/
+    : /[A-Za-z0-9_<>,\s]/;
+
+  return function TypeAnnotationReader(stream, factory) {
+    const start = stream.getPosition();
+    if (stream.current() !== ':') return null;
+    let value = ':';
+    stream.advance();
+    while (stream.current() && /\s/.test(stream.current())) {
+      value += stream.current();
+      stream.advance();
+    }
+    while (stream.current() && pattern.test(stream.current())) {
+      value += stream.current();
+      stream.advance();
+      if (/\n/.test(stream.current())) break;
+    }
+    return factory('TYPE_ANNOTATION', value.trimEnd(), start, stream.getPosition());
+  };
+}

--- a/src/plugins/flow/FlowTypePlugin.js
+++ b/src/plugins/flow/FlowTypePlugin.js
@@ -1,19 +1,8 @@
-export function FlowTypeAnnotationReader(stream, factory) {
-  const start = stream.getPosition();
-  if (stream.current() !== ':') return null;
-  let value = ':';
-  stream.advance();
-  while (stream.current() && /\s/.test(stream.current())) {
-    value += stream.current();
-    stream.advance();
-  }
-  while (stream.current() && /[A-Za-z0-9_<>,\s?]/.test(stream.current())) {
-    value += stream.current();
-    stream.advance();
-    if (/\n/.test(stream.current())) break;
-  }
-  return factory('TYPE_ANNOTATION', value.trimEnd(), start, stream.getPosition());
-}
+import { createTypeAnnotationReader } from '../common/TypeAnnotationReader.js';
+
+export const FlowTypeAnnotationReader = createTypeAnnotationReader({
+  allowQuestionMark: true
+});
 
 export const FlowTypePlugin = {
   modes: { default: [FlowTypeAnnotationReader] },

--- a/src/plugins/typescript/TypeScriptPlugin.js
+++ b/src/plugins/typescript/TypeScriptPlugin.js
@@ -1,24 +1,7 @@
 import { TSDecoratorReader } from '../common/TSDecoratorReader.js';
+import { createTypeAnnotationReader } from '../common/TypeAnnotationReader.js';
 
-export function TSTypeAnnotationReader(stream, factory) {
-  const start = stream.getPosition();
-  if (stream.current() !== ':') return null;
-  let value = ':';
-  stream.advance();
-  // Consume whitespace after colon
-  while (stream.current() && /\s/.test(stream.current())) {
-    value += stream.current();
-    stream.advance();
-  }
-  // Simple identifier or generic form
-  while (stream.current() && /[A-Za-z0-9_<>,\s]/.test(stream.current())) {
-    value += stream.current();
-    stream.advance();
-    // stop at line break
-    if (/\n/.test(stream.current())) break;
-  }
-  return factory('TYPE_ANNOTATION', value.trimEnd(), start, stream.getPosition());
-}
+export const TSTypeAnnotationReader = createTypeAnnotationReader();
 
 export function TSGenericParameterReader(stream, factory) {
   const start = stream.getPosition();


### PR DESCRIPTION
## Summary
- create reusable `createTypeAnnotationReader`
- refactor TypeScript and Flow plugins to use the shared reader

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854b8f484b48331bc1c04730d026028