### PR TITLE
[agent] refactor: centralize keyword consumption logic

### DIFF
--- a/src/lexer/ImportCallReader.js
+++ b/src/lexer/ImportCallReader.js
@@ -1,22 +1,15 @@
+import { consumeKeyword } from './utils.js';
+
 export function ImportCallReader(stream, factory) {
   const startPos = stream.getPosition();
-  if (!stream.input.startsWith('import(', startPos.index)) return null;
-
-  const saved = stream.getPosition();
-  for (const ch of 'import') {
-    if (stream.current() !== ch) {
-      stream.setPosition(saved);
-      return null;
-    }
-    stream.advance();
-  }
+  const endPos = consumeKeyword(stream, 'import');
+  if (!endPos) return null;
 
   // confirm '(' but don't consume
   if (stream.current() !== '(') {
-    stream.setPosition(saved);
+    stream.setPosition(startPos);
     return null;
   }
 
-  const endPos = stream.getPosition();
   return factory('IMPORT_CALL', 'import', startPos, endPos);
 }

--- a/src/lexer/ImportMetaReader.js
+++ b/src/lexer/ImportMetaReader.js
@@ -1,23 +1,8 @@
+import { consumeKeyword } from './utils.js';
+
 export function ImportMetaReader(stream, factory) {
   const startPos = stream.getPosition();
-  const seq = 'import.meta';
-  if (!stream.input.startsWith(seq, startPos.index)) return null;
-
-  const saved = stream.getPosition();
-  for (const ch of seq) {
-    if (stream.current() !== ch) {
-      stream.setPosition(saved);
-      return null;
-    }
-    stream.advance();
-  }
-
-  const next = stream.current();
-  if (next && /[A-Za-z0-9_$]/.test(next)) {
-    stream.setPosition(saved);
-    return null;
-  }
-
-  const endPos = stream.getPosition();
-  return factory('IMPORT_META', seq, startPos, endPos);
+  const endPos = consumeKeyword(stream, 'import.meta', { checkPrev: false });
+  if (!endPos) return null;
+  return factory('IMPORT_META', 'import.meta', startPos, endPos);
 }

--- a/src/lexer/UsingStatementReader.js
+++ b/src/lexer/UsingStatementReader.js
@@ -1,68 +1,32 @@
+import { consumeKeyword } from './utils.js';
+
 export function UsingStatementReader(stream, factory) {
   const startPos = stream.getPosition();
-  const prevIndex = startPos.index - 1;
-  const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
-  if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
 
   // await using
-  if (stream.input.startsWith('await', stream.index)) {
-    const saved = stream.getPosition();
-    let value = '';
-    for (const ch of 'await') {
-      if (stream.current() !== ch) {
-        stream.setPosition(saved);
-        return null;
-      }
-      value += ch;
-      stream.advance();
-    }
+  const saved = stream.getPosition();
+  let endPos = consumeKeyword(stream, 'await');
+  if (endPos) {
+    let value = 'await';
     if (!/\s/.test(stream.current())) {
       stream.setPosition(saved);
-      return null;
-    }
-    while (!stream.eof() && /\s/.test(stream.current())) {
-      value += stream.current();
-      stream.advance();
-    }
-    if (!stream.input.startsWith('using', stream.index)) {
-      stream.setPosition(saved);
-      return null;
-    }
-    for (const ch of 'using') {
-      if (stream.current() !== ch) {
-        stream.setPosition(saved);
-        return null;
+    } else {
+      while (!stream.eof() && /\s/.test(stream.current())) {
+        value += stream.current();
+        stream.advance();
       }
-      value += ch;
-      stream.advance();
-    }
-    const next = stream.current();
-    if (next && /[A-Za-z0-9_$]/.test(next)) {
+      const usingEnd = consumeKeyword(stream, 'using', { checkPrev: false });
+      if (usingEnd) {
+        value += 'using';
+        return factory('AWAIT_USING', value, startPos, usingEnd);
+      }
       stream.setPosition(saved);
-      return null;
     }
-    const endPos = stream.getPosition();
-    return factory('AWAIT_USING', value, startPos, endPos);
   }
 
-  if (stream.input.startsWith('using', stream.index)) {
-    const saved = stream.getPosition();
-    let value = '';
-    for (const ch of 'using') {
-      if (stream.current() !== ch) {
-        stream.setPosition(saved);
-        return null;
-      }
-      value += ch;
-      stream.advance();
-    }
-    const next = stream.current();
-    if (next && /[A-Za-z0-9_$]/.test(next)) {
-      stream.setPosition(saved);
-      return null;
-    }
-    const endPos = stream.getPosition();
-    return factory('USING', value, startPos, endPos);
+  endPos = consumeKeyword(stream, 'using');
+  if (endPos) {
+    return factory('USING', 'using', startPos, endPos);
   }
 
   return null;

--- a/src/lexer/utils.js
+++ b/src/lexer/utils.js
@@ -52,3 +52,33 @@ export function readNumberLiteral(stream, startPos, requireFractionDigits = fals
   }
   return { value, ch };
 }
+
+// Consume the given keyword at the current stream position.
+// Ensures the keyword is not part of a larger identifier by checking
+// preceding and following characters.
+// Returns the end position on success or null on failure.
+export function consumeKeyword(stream, keyword, { checkPrev = true } = {}) {
+  const startPos = stream.getPosition();
+
+  if (checkPrev) {
+    const prevIndex = startPos.index - 1;
+    const prevChar = prevIndex >= 0 ? stream.input[prevIndex] : null;
+    if (prevChar && /[A-Za-z0-9_$]/.test(prevChar)) return null;
+  }
+
+  for (const ch of keyword) {
+    if (stream.current() !== ch) {
+      stream.setPosition(startPos);
+      return null;
+    }
+    stream.advance();
+  }
+
+  const next = stream.current();
+  if (next && /[A-Za-z0-9_$]/.test(next)) {
+    stream.setPosition(startPos);
+    return null;
+  }
+
+  return stream.getPosition();
+}


### PR DESCRIPTION
## Summary
- add `consumeKeyword` utility for unified keyword parsing
- refactor import and using readers to use the new helper

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854bc88447083319af1ce6316a0f018