### PR TITLE
[agent] fix: update husky install command

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,7 +20,7 @@ GitHub Actions workflows live in the `workflows/` folder:
 
 Helper scripts used by workflows and local development are in `scripts/`:
 
-- `prepare-husky.cjs` – installs Husky git hooks.
+ - `prepare-husky.cjs` – installs Husky git hooks using `npx husky` (the `install` subcommand is deprecated).
 - `run-workflow.sh` – run lint, tests, and benchmarks locally.
 - `next-task.cjs` – print the next unchecked todo item.
 - `repo-info.cjs` – display repository info and open tasks.

--- a/.github/scripts/prepare-husky.cjs
+++ b/.github/scripts/prepare-husky.cjs
@@ -7,7 +7,7 @@ try {
   // verify we're in a git repo
   execSync('git rev-parse --git-dir', { stdio: 'ignore' });
   console.log('✔️  Git repo detected — installing Husky hooks');
-  execSync('npx husky install', { stdio: 'inherit' });
+  execSync('npx husky', { stdio: 'inherit' });
 } catch {
   console.log('ℹ️  Not a Git repo — skipping Husky install');
 }


### PR DESCRIPTION
## Summary
- use `npx husky` in `prepare-husky.cjs`
- document the deprecation of `husky install` in repo README

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854be8bfd8c833196cb38a617047b12