### PR TITLE
[agent] reuse existing agent PR if open

### DIFF
--- a/tests/openPr.test.js
+++ b/tests/openPr.test.js
@@ -2,9 +2,13 @@ import { jest } from '@jest/globals';
 import { openPr } from '../agentic-automation.js';
 
 class MockOctokit {
-  constructor() {
+  constructor(listResponse = []) {
     this.rest = {
-      pulls: { create: jest.fn().mockResolvedValue({ data: { number: 1 } }) },
+      pulls: {
+        list: jest.fn().mockResolvedValue({ data: listResponse }),
+        create: jest.fn().mockResolvedValue({ data: { number: 1 } }),
+        update: jest.fn().mockResolvedValue({ data: { number: 1 } })
+      },
       issues: { addLabels: jest.fn().mockResolvedValue({}) }
     };
   }
@@ -30,11 +34,28 @@ describe('openPr', () => {
     await openPr(mock);
 
     expect(mock.rest.pulls.create).toHaveBeenCalled();
+    expect(mock.rest.pulls.update).not.toHaveBeenCalled();
     expect(mock.rest.issues.addLabels).toHaveBeenCalledWith({
       owner: 'owner',
       repo: 'repo',
       issue_number: 1,
       labels: ['reader']
     });
+  });
+
+  test('updates existing pull request', async () => {
+    const mock = new MockOctokit([{ number: 42 }]);
+
+    await openPr(mock);
+
+    expect(mock.rest.pulls.create).not.toHaveBeenCalled();
+    expect(mock.rest.pulls.update).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      pull_number: 42,
+      title: expect.any(String),
+      body: expect.any(String)
+    });
+    expect(mock.rest.issues.addLabels).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- improve `openPr` to update an existing PR instead of creating duplicates
- adjust `openPr` test coverage for update behavior

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854beea0d348331825aba0c7fed7cb6