### PR TITLE
[agent] feat: introduce TokenReader abstraction

### DIFF
--- a/src/lexer/IdentifierReader.js
+++ b/src/lexer/IdentifierReader.js
@@ -12,17 +12,30 @@ function isIdentifierPart(ch) {
   return isIdentifierStart(ch) || (ch >= '0' && ch <= '9');
 }
 
-export function IdentifierReader(stream, factory) {
-  const startPos = stream.getPosition();
-  let ch = stream.current();
-  if (ch === null || !isIdentifierStart(ch)) return null;
+import { TokenReader } from './TokenReader.js';
 
-  let value = '';
-  while (ch !== null && isIdentifierPart(ch)) {
-    value += ch;
-    stream.advance();
-    ch = stream.current();
+export class IdentifierTokenReader extends TokenReader {
+  read(stream, factory) {
+    const startPos = stream.getPosition();
+    let ch = stream.current();
+    if (ch === null || !isIdentifierStart(ch)) return null;
+
+    let value = '';
+    while (ch !== null && isIdentifierPart(ch)) {
+      value += ch;
+      stream.advance();
+      ch = stream.current();
+    }
+    const endPos = stream.getPosition();
+    return factory('IDENTIFIER', value, startPos, endPos);
   }
-  const endPos = stream.getPosition();
-  return factory('IDENTIFIER', value, startPos, endPos);
 }
+
+// Preserve existing functional interface
+export function IdentifierReader(stream, factory, engine) {
+  const reader = new IdentifierTokenReader();
+  return reader.read(stream, factory, engine);
+}
+
+// Named export for compatibility
+export const IdentifierReaderClass = IdentifierTokenReader;

--- a/src/lexer/LexerEngine.js
+++ b/src/lexer/LexerEngine.js
@@ -10,6 +10,7 @@ import { baseReaders } from './defaultReaders.js';
 import { Token } from './Token.js';
 import { LexerError } from './LexerError.js';
 import { JavaScriptGrammar } from '../grammar/JavaScriptGrammar.js';
+import { runReader } from './TokenReader.js';
 
 /**
  * LexerEngine orchestrates all token readers to produce a stream of Tokens.
@@ -83,7 +84,7 @@ export class LexerEngine {
   _readTrivia(factory) {
     const { stream, triviaReaders } = this;
     for (const Reader of triviaReaders) {
-      const tok = Reader(stream, factory, this);
+      const tok = runReader(Reader, stream, factory, this);
       if (tok) return tok;
     }
     return null;
@@ -120,7 +121,7 @@ export class LexerEngine {
 
       // 2. Try each reader in sequence
       for (const Reader of readers) {
-        const result = Reader(stream, factory, this);
+        const result = runReader(Reader, stream, factory, this);
         if (result) {
           if (result instanceof LexerError) {
             if (this.errorRecovery) {

--- a/src/lexer/TokenReader.js
+++ b/src/lexer/TokenReader.js
@@ -1,0 +1,15 @@
+export class TokenReader {
+  read(_stream, _factory, _engine) {
+    throw new Error('read() must be implemented');
+  }
+}
+
+export function runReader(reader, stream, factory, engine) {
+  if (typeof reader === 'function') {
+    return reader(stream, factory, engine);
+  }
+  if (reader && typeof reader.read === 'function') {
+    return reader.read(stream, factory, engine);
+  }
+  throw new TypeError('Invalid reader');
+}

--- a/src/lexer/defaultReaders.js
+++ b/src/lexer/defaultReaders.js
@@ -1,4 +1,4 @@
-import { IdentifierReader } from './IdentifierReader.js';
+import { IdentifierReader, IdentifierReaderClass } from './IdentifierReader.js';
 import { BinaryReader } from './BinaryReader.js';
 import { OctalReader } from './OctalReader.js';
 import { HexReader } from './HexReader.js';
@@ -47,7 +47,7 @@ export const baseReaders = [
   FunctionSentReader,
   ImportAssertionReader,
   RecordAndTupleReader,
-  IdentifierReader,
+  new IdentifierReaderClass(),
   UnicodeIdentifierReader,
   UnicodeEscapeIdentifierReader,
   HexReader,


### PR DESCRIPTION
## Summary
- add `TokenReader` base class and `runReader` helper
- implement `IdentifierTokenReader` using the new base class
- allow `LexerEngine` to execute both functions and class-based readers
- update default readers to use the new class

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854c035dbdc83318d708d2c08313d86