### PR TITLE
[agent] automate project board setup

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -25,6 +25,7 @@ Helper scripts used by workflows and local development are in `scripts/`:
 - `next-task.cjs` – print the next unchecked todo item.
 - `repo-info.cjs` – display repository info and open tasks.
 - `check-drift.js` – open issues for spec/implementation drift.
+- `setup-project-board.js` – create a classic project board with standard columns.
 - `compare-benchmark.js` – fail CI on benchmark regressions.
 - `generate-tests.js` – placeholder for test generation from the spec.
 - `check-coverage.js` – ensure test coverage meets the required threshold.

--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Ensure a classic GitHub project board exists with Todo/In Progress/Done columns.
+ * Requires:
+ *   GITHUB_TOKEN      – PAT or Actions token
+ *   GITHUB_REPOSITORY – "owner/repo"
+ *   PROJECT_NAME      – board name (defaults to "Automation")
+ */
+import { Octokit } from '@octokit/rest';
+
+const { GITHUB_TOKEN: token, GITHUB_REPOSITORY: repoFull, PROJECT_NAME } = process.env;
+if (!token || !repoFull) {
+  console.log('setup-project-board: missing credentials – skipping.');
+  process.exit(0);
+}
+
+const boardName = PROJECT_NAME || 'Automation';
+const [owner, repo] = repoFull.split('/');
+const octokit = new Octokit({ auth: token });
+
+async function ensureColumns(projectId) {
+  const { data: columns } = await octokit.request('GET /projects/{project_id}/columns', {
+    project_id: projectId,
+    mediaType: { previews: ['inertia'] }
+  });
+  const needed = ['Todo', 'In Progress', 'Done'];
+  for (const name of needed) {
+    if (columns.some(c => c.name === name)) continue;
+    await octokit.request('POST /projects/{project_id}/columns', {
+      project_id: projectId,
+      name,
+      mediaType: { previews: ['inertia'] }
+    });
+  }
+}
+
+(async () => {
+  let project = (await octokit.request('GET /repos/{owner}/{repo}/projects', {
+    owner,
+    repo,
+    mediaType: { previews: ['inertia'] }
+  })).data.find(p => p.name === boardName);
+
+  if (!project) {
+    project = (await octokit.request('POST /repos/{owner}/{repo}/projects', {
+      owner,
+      repo,
+      name: boardName,
+      body: 'Automated project board for issue triage.',
+      mediaType: { previews: ['inertia'] }
+    })).data;
+    console.log(`Created project board '${boardName}'`);
+  } else {
+    console.log(`Project board '${boardName}' already exists`);
+  }
+  await ensureColumns(project.id);
+})();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ This repository is optimized for iterative development by Codex agents.
 2. Review `docs/TASK_BREAKDOWN.md` for historical context if needed.
 3. Consult `docs/LEXER_SPEC.md` and other docs for background.
 4. Implement code changes in `src/` and update or add tests under `tests/`.
-5. Before every commit, run:
+5. Ensure an issue board exists by running `npm run setup-board` once.
+6. Before every commit, run:
 
    npm run lint && npm test -- --coverage
 Ensure test coverage stays above 90%.
@@ -22,7 +23,7 @@ Ensure test coverage stays above 90%.
 
 
 npm run workflow   # requires GitHub creds; otherwise just lint & tests run
-Commit Guidelines
+7. Commit Guidelines
 Use Conventional Commits (feat, fix, docs, style, refactor, perf, test, chore).
 
 Keep commits focused and small.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 1. Choose an open issue or propose a new enhancement.
 2. Read its spec in `docs/LEXER_SPEC.md`.
-3. Run `npm run lint && npm test -- --coverage` to see failing tests.
-4. Implement the functionality in the corresponding stub file.
-5. Commit directly to the shared branch and open a PR.
-6. Label the PR with `reader` to enable the auto‑merge workflow.
-7. Ensure CI (lint, tests, coverage ≥ 90%) passes and obtain at least one approving review.
-8. Once these requirements are met, the **Auto‑Merge Reader PRs** action will squash merge the PR automatically.
+3. Run `npm run setup-board` once to create the project board.
+4. Run `npm run lint && npm test -- --coverage` to see failing tests.
+5. Implement the functionality in the corresponding stub file.
+6. Commit directly to the shared branch and open a PR.
+7. Label the PR with `reader` to enable the auto‑merge workflow.
+8. Ensure CI (lint, tests, coverage ≥ 90%) passes and obtain at least one approving review.
+9. Once these requirements are met, the **Auto‑Merge Reader PRs** action will squash merge the PR automatically.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Print an overview of available scripts and open tasks:
 
 
 npm run repo-info
+Issue Board
+Set up a project board with standard columns:
+
+```
+npm run setup-board
+```
+
 Agent Workflow
 Automated agents coordinate through GitHub branches. A typical session:
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "publish:extension": "npm --prefix extension install && npm --prefix extension run publish",
     "workflow": "bash .github/scripts/run-workflow.sh",
     "next-task": "node .github/scripts/next-task.cjs",
-    "repo-info": "node .github/scripts/repo-info.cjs"
+    "repo-info": "node .github/scripts/repo-info.cjs",
+    "setup-board": "node .github/scripts/setup-project-board.js"
   },
   "keywords": [
     "lexer",


### PR DESCRIPTION
## Summary
- add a script to create a classic project board and ensure standard columns
- document the new `setup-board` workflow script and usage instructions
- update agent workflow docs with board setup step

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854c2f4795c8331bf7972ee0bfc20eb