### PR TITLE
[agent] fix lint warnings for unused params

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,10 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "no-unused-vars": "warn",
+    "no-unused-vars": [
+      "warn",
+      { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }
+    ],
     "no-console": "off",
   },
 };

--- a/src/lexer/defaultReaders.js
+++ b/src/lexer/defaultReaders.js
@@ -1,4 +1,4 @@
-import { IdentifierReader, IdentifierReaderClass } from './IdentifierReader.js';
+import { IdentifierReaderClass } from './IdentifierReader.js';
 import { BinaryReader } from './BinaryReader.js';
 import { OctalReader } from './OctalReader.js';
 import { HexReader } from './HexReader.js';


### PR DESCRIPTION
## Summary
- silence unused variable warnings for underscored params
- remove unused `IdentifierReader` import

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854c844fe0c83318a466f0c9817ee0b