### PR TITLE
[agent] fix checkCoverage missing file error

### DIFF
--- a/src/utils/checkCoverage.js
+++ b/src/utils/checkCoverage.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
 
 export function checkCoverage(threshold = 90, reportPath = 'coverage/clover.xml') {
+  if (!fs.existsSync(reportPath)) {
+    throw new Error(`Coverage report not found: ${reportPath}`);
+  }
   const xml = fs.readFileSync(reportPath, 'utf8');
   const metrics = xml.match(/<metrics[^>]+>/);
   if (!metrics) throw new Error('Metrics not found in coverage report');

--- a/tests/checkCoverage.test.js
+++ b/tests/checkCoverage.test.js
@@ -25,4 +25,8 @@ describe('checkCoverage', () => {
     fs.writeFileSync(file, xml);
     expect(() => checkCoverage(90, file)).toThrow('Coverage 85% below threshold 90%');
   });
+
+  test('throws when report file missing', () => {
+    expect(() => checkCoverage(90, file)).toThrow(`Coverage report not found: ${file}`);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `checkCoverage` gracefully handles missing coverage reports
- test error message when coverage file is absent

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6854cb1f137883319f62686b269236eb