### PR TITLE
[agent] align board config with new project name

### DIFF
--- a/.github/scripts/setup-project-board.js
+++ b/.github/scripts/setup-project-board.js
@@ -15,10 +15,11 @@ import { Octokit } from '@octokit/rest';
 
 const repoFull   = process.env.GITHUB_REPOSITORY;
 const boardName  = process.env.PROJECT_NAME || 'Experimental Lexer';
-const token      = process.env.GITHUB_TOKEN;               // Actions token only
+// Prefer the default GITHUB_TOKEN but allow a custom PAT via TOKEN
+const token      = process.env.GITHUB_TOKEN || process.env.TOKEN;
 
 if (!repoFull || !token) {
-  console.warn('setup-project-board: missing GITHUB_REPOSITORY or GITHUB_TOKEN – skipping.');
+  console.warn('setup-project-board: missing GITHUB_REPOSITORY or token – skipping.');
   process.exit(0);
 }
 

--- a/.github/scripts/setup-project-v2.js
+++ b/.github/scripts/setup-project-v2.js
@@ -6,7 +6,7 @@
  * Env:
  *   • GITHUB_REPOSITORY  owner/repo         (always present in Actions)
  *   • TOKEN              PAT-classic with project:write scope
- *   • PROJECT_NAME       optional – defaults to "Automation"
+ *   • PROJECT_NAME       optional – defaults to "Experimental Lexer"
  */
 
 import process from 'node:process';
@@ -14,7 +14,7 @@ import { graphql } from '@octokit/graphql';
 
 const repoFull  = process.env.GITHUB_REPOSITORY;
 const token     = process.env.TOKEN;
-const boardName = process.env.PROJECT_NAME || 'Automation';
+const boardName = process.env.PROJECT_NAME || 'Experimental Lexer';
 
 if (!repoFull || !token) {
   console.warn('setup-project-v2: missing GITHUB_REPOSITORY or TOKEN – skipping.');

--- a/.github/workflows/agent-pr.yml
+++ b/.github/workflows/agent-pr.yml
@@ -14,7 +14,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'reader')
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation
+      PROJECT_NAME: Experimental Lexer
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/agent-workflow.yml
+++ b/.github/workflows/agent-workflow.yml
@@ -21,7 +21,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation      # classic board name for helper scripts
+      PROJECT_NAME: Experimental Lexer      # classic board name for helper scripts
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -37,7 +37,7 @@ jobs:
     if: ${{ github.event_name == 'issues' || github.event_name == 'issue_comment' }}
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation
+      PROJECT_NAME: Experimental Lexer
     steps:
       - run: |
           node .github/scripts/close-todo.js
@@ -49,7 +49,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation
+      PROJECT_NAME: Experimental Lexer
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -67,7 +67,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation
+      PROJECT_NAME: Experimental Lexer
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -14,7 +14,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME:     Automation
+      PROJECT_NAME:     Experimental Lexer
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     env:
-      PROJECT_NAME: Automation
+      PROJECT_NAME: Experimental Lexer
     steps:
       - uses: actions/checkout@v4
       - uses: actions/stale@v5


### PR DESCRIPTION
## Summary
- allow PAT via `TOKEN` in setup-project-board
- default v2 board name to Experimental Lexer
- update workflows to use Experimental Lexer board name

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6854e3e928648331b4e466778e120cef